### PR TITLE
nmdctl: filesystem + LUKS support: status/mount/unmount

### DIFF
--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -327,12 +327,15 @@ determine_array_health() {
     local total_slots=$(get_defined_slots_count)
 
     # Count how many disks have been imported
+    # and how many read/write errors there are
     local imported_disks=0
+    local disks_num_errors=0
     for slot in $(get_defined_slots); do
         local rdevname="${NMDSTAT_VALUES[rdevName.$slot]}"
         if [ -n "$rdevname" ] && [ "$rdevname" != "none" ]; then
             imported_disks=$((imported_disks + 1))
         fi
+        disks_num_errors=$((disks_num_errors + "${NMDSTAT_VALUES[rdevNumErrors.$slot]}"))
     done
 
     # Check for critical error conditions first
@@ -370,6 +373,9 @@ determine_array_health() {
         # Remove trailing comma and space
         health_details=${issues%, }
     # Check if array is stopped but healthy
+    elif [ "$disks_num_errors" -gt 0 ]; then
+        health_status="${YELLOW}WARNING${NC}"
+        health_details="All disks present, but some have read or write errors ($disks_num_errors total)"
     elif [ "$mdstate" = "STOPPED" ]; then
         health_status="${YELLOW}READY${NC}"
         health_details="All disks imported but array is not started"
@@ -593,7 +599,7 @@ display_disk_entry() {
 
     # Add indicator for disk errors
     if [ -n "$rdevnumerrors" ] && [ "$rdevnumerrors" -gt 0 ]; then
-        status_formatted="$status_formatted ($rdevnumerrors errs)"
+        status_formatted="$status_formatted $(echo -e "${RED}($rdevnumerrors errs)${NC}")"
         # Account for the extra text in the visible length
         visible_length=$((visible_length + ${#rdevnumerrors} + 8))
     fi

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -577,6 +577,7 @@ display_disk_entry() {
     local rdevnumerrors="${7:-0}"
     local diskname="$8"
     local mdstate="$9"
+    local fs_type=""
 
     # Convert size to GB
     local sizegb=0
@@ -602,10 +603,24 @@ display_disk_entry() {
     printf "%$((21 - visible_length))s" " " # Use visible length for padding
 
     if [ "$mdstate" = "STARTED" ]; then
-        # Include disk name column when array is started
-        printf "%-10s  %-14s  %-8s  %s\n" "${rdevname:-none}" "${diskname:-${slottype:-$idx}}" "$sizegb" "$diskid"
+        # Get filesystem type for data disks when array is started
+        if [ -n "$rdevname" ] && [ "$rdevname" != "none" ]; then
+            # For data disks, get the filesystem type
+            if [[ "$idx" != "0" && "$idx" != "29" ]]; then
+                # Check if device exists before calling blkid
+                if [ -b "/dev/$rdevname" ]; then
+                    fs_type=$(get_fs_type "/dev/$rdevname")
+                fi
+            else
+                # For parity disks, use slot type (P or Q)
+                fs_type="${slottype:-}"
+            fi
+        fi
+
+        # Include disk name and filesystem columns when array is started
+        printf "%-10s  %-8s  %-14s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-}" "$diskid"
     else
-        # Original format without disk name
+        # Original format without disk name and filesystem
         printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
     fi
 }
@@ -619,8 +634,8 @@ show_disk_status() {
     echo ""
 
     if [ "$mdstate" = "STARTED" ]; then
-        echo -e "Slot  Status               Device      Disk Name       Size(GB)  Drive ID"
-        echo -e "----  -------------------  ----------  -------------   --------  -------------------------------------"
+        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Drive ID"
+        echo -e "----  -------------------  ----------  --------  -------------   --------  -------------------------------------"
     else
         echo -e "Slot  Status               Device      Size(GB)  Drive ID"
         echo -e "----  -------------------  ----------  --------  -------------------------------------"
@@ -694,6 +709,27 @@ show_disk_status() {
     done
 
     return 0
+}
+
+# Get filesystem type for a device using blkid
+get_fs_type() {
+    local device="$1"
+
+    if [ -b "$device" ]; then
+        # Run blkid to get the filesystem type
+        local fs_type=$(blkid -o value -s TYPE "$device" 2>/dev/null)
+
+        # Convert zfs_member to just zfs
+        if [ "$fs_type" = "zfs_member" ]; then
+            echo "zfs"
+        else
+            echo "${fs_type:-unknown}"
+        fi
+        return 0
+    fi
+
+    echo ""
+    return 1
 }
 
 # Get disk size in 1K blocks

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2155
+# shellcheck disable=SC2155,SC2207
 #
 # nmdctl - NonRAID array management utility
 #
@@ -116,8 +116,7 @@ check_module_loaded() {
             echo -e "${YELLOW}A new superblock will be created when the array is started${NC}"
         fi
 
-        modprobe nonraid super="$superblock"
-        if [ $? -ne 0 ]; then
+        if ! modprobe nonraid super="$superblock"; then
             echo -e "${RED}Error: Failed to load nonraid module${NC}"
             return 1
         fi
@@ -126,8 +125,7 @@ check_module_loaded() {
     else
         echo -e "${RED}Error: nonraid module is not loaded${NC}"
         echo -e "Superblock file not found: $superblock"
-        echo -e "Please load the module with: ${YELLOW}modprobe nonraid super=/path/to/superblock.dat${NC}"
-        echo -e "Or specify superblock with: ${YELLOW}nmdctl --super /path/to/superblock.dat ...${NC}"
+        echo -e "To create an array with this new superblock, run: ${YELLOW}nmdctl --super $superblock create${NC}"
         return 1
     fi
 }
@@ -530,7 +528,7 @@ show_resync_status() {
 
         # Calculate elapsed time (mdResyncDt is in seconds)
         local elapsed_time=$mdresyncdt
-        local elapsed_formatted=$(format_time_duration $elapsed_time)
+        local elapsed_formatted=$(format_time_duration "$elapsed_time")
 
         # Calculate estimated time remaining
         local eta_seconds=0
@@ -674,7 +672,7 @@ show_disk_status() {
             local rdevnumerrors="${NMDSTAT_VALUES[rdevNumErrors.$idx]}"
 
             # For DISK_NEW, get size from rdevSize instead of diskSize
-            if [[ ("$rdevstatus" = "DISK_NEW" || "$rdevstatus" = "DISK_DSBL_NEW") ]] && [ -z "$disksize" -o "$disksize" = "0" ]; then
+            if [[ ("$rdevstatus" = "DISK_NEW" || "$rdevstatus" = "DISK_DSBL_NEW") ]] && { [ -z "$disksize" ] || [ "$disksize" = "0" ]; }; then
                 local rdevsize="${NMDSTAT_VALUES[rdevSize.$idx]}"
                 if [ -n "$rdevsize" ] && [ "$rdevsize" -gt 0 ]; then
                     disksize="$rdevsize"
@@ -712,7 +710,7 @@ show_disk_status() {
             local rdevnumerrors="${NMDSTAT_VALUES[rdevNumErrors.$idx]}"
 
             # For DISK_NEW, get size from rdevSize instead of diskSize
-            if [ "$rdevstatus" = "DISK_NEW" ] && [ -z "$disksize" -o "$disksize" = "0" ]; then
+            if [ "$rdevstatus" = "DISK_NEW" ] && { [ -z "$disksize" ] || [ "$disksize" = "0" ]; }; then
                 local rdevsize="${NMDSTAT_VALUES[rdevSize.$idx]}"
                 if [ -n "$rdevsize" ] && [ "$rdevsize" -gt 0 ]; then
                     disksize="$rdevsize"
@@ -779,7 +777,7 @@ get_mountpoint() {
             # For ZFS, we need to identify the pool name and dataset
             # Get ZFS pool name that contains this device
             if command -v zpool >/dev/null 2>&1; then
-                local pool=$(zpool list -H -o name,health | awk '{print $1}' | while read pool; do
+                local pool=$(zpool list -H -o name,health | awk '{print $1}' | while read -r pool; do
                     if zpool status "$pool" 2>/dev/null | grep -q "$device"; then
                         echo "$pool"
                         break
@@ -991,7 +989,7 @@ import_disks() {
                         echo -e "  Expected size : $configured_size KB"
 
                         # Ask for confirmation
-                        read -p "Use the configured size instead of detected size? (y/N): " confirm
+                        read -r -p "Use the configured size instead of detected size? (y/N): " confirm
                         if [[ "$confirm" =~ ^[Yy]$ ]]; then
                             size_to_use="$configured_size"
                             echo -e "Using configured size: ${BLUE}$configured_size KB${NC}"
@@ -1023,6 +1021,7 @@ import_disks() {
     if [ "$num_disks" -eq 0 ]; then
         # Check if disks were already imported (check for any rdevName values)
         local already_imported=0
+        # shellcheck disable=SC2013
         for slot in $(grep -E "^diskId\.[0-9]+" /proc/nmdstat | cut -d'.' -f2 | cut -d'=' -f1); do
             local rdevname=$(get_nmdstat_value "rdevName.$slot")
             if [ -n "$rdevname" ] && [ "$rdevname" != "none" ]; then
@@ -1147,7 +1146,7 @@ start_array() {
         esac
 
         # Ask for confirmation
-        read -p "Do you want to continue starting the array in this state? (y/N): " confirm
+        read -r -p "Do you want to continue starting the array in this state? (y/N): " confirm
         if [[ "$confirm" =~ ^[Yy]$ ]]; then
             echo "Proceeding with array start in $mdstate state"
             if ! run_nmd_command "start $mdstate"; then
@@ -1258,7 +1257,7 @@ list_available_devices() {
         fi
 
         # Check if the device has exactly one partition
-        local partition_count=$(ls -l ${dev}* 2>/dev/null | grep -cE "${dev}[0-9]+")
+        local partition_count=$(grep -c "$(basename "${dev}")[0-9]" /proc/partitions)
         if [ "$partition_count" -eq 1 ]; then
             # Get the partition device
             local partition=""
@@ -1357,7 +1356,7 @@ create_array() {
 
     # Ask for array label
     local array_label=""
-    read -p "Enter a label for the array (optional): " array_label
+    read -r -p "Enter a label for the array (optional): " array_label
     if [ -n "$array_label" ]; then
         # Set array label if provided
         echo "Setting array label: $array_label"
@@ -1403,7 +1402,7 @@ create_array() {
             echo -e " 1-28: Data disk"
             echo -e " s: Skip this disk"
             echo -e " f: Finish array creation"
-            read -p "Choice: " choice
+            read -r -p "Choice: " choice
 
             local slot=""
             case "$choice" in
@@ -1479,7 +1478,7 @@ create_array() {
 
     # Ask if user wants to start the array now
     echo ""
-    read -p "Do you want to start the array now? (y/N): " start_now
+    read -r -p "Do you want to start the array now? (y/N): " start_now
     if [[ "$start_now" =~ ^[Yy]$ ]]; then
         start_array
     else
@@ -1536,7 +1535,7 @@ add_disk() {
     if [ "$imported_disks" -lt "$total_slots" ]; then
         echo -e "${YELLOW}Warning: Not all disks have been imported ($imported_disks/$total_slots)${NC}"
         echo -e "${YELLOW}It's recommended to import all existing disks before adding a new one${NC}"
-        read -p "Continue anyway? (y/N): " confirm
+        read -rp "Continue anyway? (y/N): " confirm
         if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
             echo "Operation cancelled."
             return 1
@@ -1720,7 +1719,7 @@ add_disk() {
 
     # Select device
     while true; do
-        read -p "Enter device number to add (1-${#available_devices[@]}) or 'q' to quit: " choice
+        read -r -p "Enter device number to add (1-${#available_devices[@]}) or 'q' to quit: " choice
 
         if [ "$choice" = "q" ] || [ "$choice" = "Q" ]; then
             echo "Operation cancelled."
@@ -1758,7 +1757,7 @@ add_disk() {
         echo -e " Q or 29: Second parity disk (optional)"
         echo -e " 1-28: Data disk"
         echo -e " a: Abort adding disk"
-        read -p "Choice: " choice
+        read -r -p "Choice: " choice
 
         if [ "$choice" = "a" ] || [ "$choice" = "A" ]; then
             echo "Operation cancelled."
@@ -1804,7 +1803,7 @@ add_disk() {
 
     # Confirm selection
     echo -e "You are about to add: ${BLUE}$(basename "$selected_dev")${NC} to slot ${BLUE}$slot_display${NC}"
-    read -p "Proceed with adding this disk? (y/N): " confirm
+    read -r -p "Proceed with adding this disk? (y/N): " confirm
 
     if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
         echo "Operation cancelled."
@@ -1948,7 +1947,7 @@ unassign_disk() {
     echo ""
 
     # Ask for confirmation
-    read -p "Are you sure you want to unassign this disk? (y/N): " confirm
+    read -r -p "Are you sure you want to unassign this disk? (y/N): " confirm
     if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
         echo "Operation cancelled."
         return 1
@@ -1998,7 +1997,7 @@ reload_module() {
         echo -e "${YELLOW}This will create a new superblock when the array is started.${NC}"
 
         # Ask for confirmation if creating a new superblock
-        read -p "Continue with a new superblock? (y/N): " confirm
+        read -r -p "Continue with a new superblock? (y/N): " confirm
         if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
             echo "Operation cancelled."
             return 1

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -208,6 +208,22 @@ get_defined_slots() {
     grep -E "^diskId\.[0-9]+=[^=]+" /proc/nmdstat | cut -d'.' -f2 | cut -d'=' -f1
 }
 
+# Format time duration in seconds to a human-readable format (HH:MM:SS)
+format_time_duration() {
+    local seconds=$1
+    local hours=$(( seconds / 3600 ))
+    local minutes=$(( (seconds % 3600) / 60 ))
+    local secs=$(( seconds % 60 ))
+
+    if [ "$hours" -gt 0 ]; then
+        printf "%d:%02d:%02d" "$hours" "$minutes" "$secs"
+    elif [ "$minutes" -gt 0 ]; then
+        printf "%d:%02d" "$minutes" "$secs"
+    else
+        printf "%d sec" "$secs"
+    fi
+}
+
 # Show current array status
 show_status() {
     if ! check_nmdstat_exists; then
@@ -404,10 +420,30 @@ show_status() {
             rate=$(( mdresyncdb / mdresyncdt ))
         fi
 
+        # Convert rate from KB/s to MB/s (using bash arithmetic for compatibility)
+        local rate_mb_int=$(( rate * 100 / 1024 ))
+        local rate_mb_whole=$(( rate_mb_int / 100 ))
+        local rate_mb_frac=$(( rate_mb_int % 100 ))
+        local rate_mb="${rate_mb_whole}.$(printf "%02d" $rate_mb_frac)"
+
+        # Calculate elapsed time (mdResyncDt is in seconds)
+        local elapsed_time=$mdresyncdt
+        local elapsed_formatted=$(format_time_duration $elapsed_time)
+
+        # Calculate estimated time remaining
+        local eta_seconds=0
+        if [ "$rate" -gt 0 ] && [ "$mdresyncsize" -gt "$mdresyncpos" ]; then
+            local remaining_blocks=$(( mdresyncsize - mdresyncpos ))
+            eta_seconds=$(( remaining_blocks / rate ))
+        fi
+        local eta_formatted=$(format_time_duration $eta_seconds)
+
         echo ""
         echo -e "Operation     : ${BLUE}$mdresyncaction${NC}"
         echo -e "Progress      : $progress% ($mdresyncpos/$mdresyncsize blocks)"
-        echo -e "Speed         : $rate KB/s"
+        echo -e "Speed         : $rate_mb MB/s"
+        echo -e "Elapsed Time  : $elapsed_formatted"
+        echo -e "ETA           : $eta_formatted"
     fi
 
     # List all disks in the array

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -2071,6 +2071,14 @@ main() {
                 SUPERBLOCK_PATH="$2"
                 shift 2
                 ;;
+            "--no-color")
+                RED=""
+                GREEN=""
+                BLUE=""
+                YELLOW=""
+                NC=""
+                shift
+                ;;
             "-h"|"--help"|"help")
                 usage
                 ;;

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -54,6 +54,9 @@ usage() {
     echo ""
     echo "Global Options:"
     echo "  -s, --super PATH            Superblock file path to use when loading the module (default: $DEFAULT_SUPERBLOCK)"
+    echo "  -k, --keyfile PATH          Path to LUKS keyfile to use during mounting (default: $LUKS_KEYFILE)"
+    echo "  -u, --unattended            Enable unattended mode"
+    echo "  -v, --verbose               Enable verbose output"
     echo "  -h, --help                  Display this help message"
     echo ""
     exit 1
@@ -646,10 +649,22 @@ display_disk_entry() {
         fi
 
         # Include disk name, filesystem, mountpoint and usage columns when array is started
-        printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
+        if [ "$VERBOSE" -eq 1 ]; then
+            # Show drive ID when verbose mode is enabled
+            printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
+        else
+            # Omit drive ID in normal mode
+            printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage"
+        fi
     else
         # Original format without disk name and filesystem
-        printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+        if [ "$VERBOSE" -eq 1 ]; then
+            # Show drive ID when verbose mode is enabled
+            printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+        else
+            # Omit drive ID in normal mode
+            printf "%-10s  %-8s\n" "${rdevname:-none}" "$sizegb"
+        fi
     fi
 }
 
@@ -662,11 +677,21 @@ show_disk_status() {
     echo ""
 
     if [ "$mdstate" = "STARTED" ]; then
-        echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage     Drive ID"
-        echo -e "----  -------------------  ----------  --------  ----------  ------------  ---------------   --------  -------------------------------------"
+        if [ "$VERBOSE" -eq 1 ]; then
+            echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage     Drive ID"
+            echo -e "----  -------------------  ----------  --------  ----------  ------------  ---------------   --------  -------------------------------------"
+        else
+            echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage"
+            echo -e "----  -------------------  ----------  --------  ----------  ------------  ---------------   --------"
+        fi
     else
-        echo -e "Slot  Status               Device      Size(GB)  Drive ID"
-        echo -e "----  -------------------  ----------  --------  -------------------------------------"
+        if [ "$VERBOSE" -eq 1 ]; then
+            echo -e "Slot  Status               Device      Size(GB)  Drive ID"
+            echo -e "----  -------------------  ----------  --------  -------------------------------------"
+        else
+            echo -e "Slot  Status               Device      Size(GB)"
+            echo -e "----  -------------------  ----------  --------"
+        fi
     fi
 
     # Special handling for parity disks
@@ -1017,6 +1042,12 @@ import_disks() {
                         echo -e "${YELLOW}Warning: Size mismatch for disk in slot $slot${NC}"
                         echo -e "  Partition size: $disk_size KB"
                         echo -e "  Expected size : $configured_size KB"
+
+                        if [ "$UNATTENDED" -eq 1 ]; then
+                            # If unattended, do not continue import
+                            echo -e "${RED}Error: Size mismatch for disk in slot $slot (unattended mode)${NC}"
+                            continue
+                        fi
 
                         # Ask for confirmation
                         read -r -p "Use the configured size instead of detected size? (y/N): " confirm

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -338,6 +338,7 @@ determine_array_health() {
         disks_num_errors=$((disks_num_errors + "${NMDSTAT_VALUES[rdevNumErrors.$slot]}"))
     done
 
+    local return_code=1
     # Check for critical error conditions first
     if [[ "$mdstate" = "ERROR:"* ]]; then
         health_status="${RED}ERROR${NC}"
@@ -383,6 +384,7 @@ determine_array_health() {
     else
         health_status="${GREEN}HEALTHY${NC}"
         health_details="All disks present and functioning"
+        return_code=0
     fi
 
     # Display the health status
@@ -392,6 +394,8 @@ determine_array_health() {
     else
         echo ""
     fi
+
+    return $return_code
 }
 
 # Show current array status
@@ -411,6 +415,7 @@ show_status() {
 
     # Show array health status
     determine_array_health
+    local array_health=$?
 
     # Show array size and parity information
     show_array_size_and_parity
@@ -421,7 +426,7 @@ show_status() {
     # Show disk status
     show_disk_status
 
-    return 0
+    return $array_health
 }
 
 # Display array size and parity information

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -3,6 +3,12 @@
 # nmdctl - NonRAID array management utility
 #
 
+# Check for bash version 4 or higher (needed for associative arrays)
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "Error: This script requires bash version 4 or higher"
+    exit 1
+fi
+
 # Colors for pretty output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -13,6 +19,9 @@ NC='\033[0m' # No Color
 # Default superblock path
 DEFAULT_SUPERBLOCK="/nonraid.dat"
 SUPERBLOCK_PATH=""
+
+# Global associative array for nmdstat values
+declare -A NMDSTAT_VALUES
 
 # Display usage information
 usage() {
@@ -73,7 +82,11 @@ check_module_loaded() {
     if lsmod | grep -q nonraid; then
         # For create_array, verify the module is using the correct superblock
         if [ "$is_create_command" -eq 1 ] && [ -f /proc/nmdstat ]; then
-            local current_superblock=$(get_nmdstat_value "sbName")
+            # Get all nmdstat values if we haven't already
+            if [ ${#NMDSTAT_VALUES[@]} -eq 0 ]; then
+                get_all_nmdstat_values NMDSTAT_VALUES
+            fi
+            local current_superblock="${NMDSTAT_VALUES[sbName]}"
 
             # If the current superblock doesn't match what we want to use
             if [ "$current_superblock" != "$superblock" ] && [ -n "$current_superblock" ] && [ "$current_superblock" != "(null)" ]; then
@@ -121,6 +134,11 @@ check_module_loaded() {
 # Check if /proc/nmdstat exists
 check_nmdstat_exists() {
     if [ ! -f /proc/nmdstat ]; then
+        # Clear the NMDSTAT_VALUES array since /proc/nmdstat doesn't exist
+        for key in "${!NMDSTAT_VALUES[@]}"; do
+            unset NMDSTAT_VALUES["$key"]
+        done
+
         # Try to load the module first if it's not loaded
         if ! lsmod | grep -q nonraid; then
             check_module_loaded
@@ -136,7 +154,27 @@ check_nmdstat_exists() {
     return 0
 }
 
-# Get value from nmdstat
+# Get all values from nmdstat and store them in an associative array
+# Usage: get_all_nmdstat_values nmdstat_array
+# Afterward, access values with ${nmdstat_array["key"]}
+get_all_nmdstat_values() {
+    local -n array_ref=$1
+
+    # Clear the array first
+    for key in "${!array_ref[@]}"; do
+        unset array_ref["$key"]
+    done
+
+    # Read all values from /proc/nmdstat
+    while IFS='=' read -r key value; do
+        array_ref["$key"]="$value"
+    done < <(cat /proc/nmdstat 2>/dev/null)
+
+    # Return success only if we read something
+    [ ${#array_ref[@]} -gt 0 ]
+}
+
+# Get value from nmdstat (for backward compatibility)
 get_nmdstat_value() {
     grep -E "^$1=" /proc/nmdstat | cut -d= -f2
 }
@@ -197,15 +235,40 @@ format_array_state() {
 # Get count of defined disk slots in the array
 # Returns the count of all slots with a defined disk
 get_defined_slots_count() {
-    # We check for non-empty diskId values
-    grep -c -E "^diskId\.[0-9]+=[^=]+" /proc/nmdstat
+    # If NMDSTAT_VALUES is empty, populate it first
+    if [ ${#NMDSTAT_VALUES[@]} -eq 0 ]; then
+        get_all_nmdstat_values NMDSTAT_VALUES
+    fi
+
+    local count=0
+    # Count all keys matching diskId.X with non-empty values
+    for key in "${!NMDSTAT_VALUES[@]}"; do
+        if [[ $key =~ ^diskId\.[0-9]+$ ]] && [ -n "${NMDSTAT_VALUES[$key]}" ]; then
+            count=$((count + 1))
+        fi
+    done
+
+    echo "$count"
 }
 
 # Get array of defined slot numbers
 # Returns space-separated list of slot numbers that have disks defined
 get_defined_slots() {
-    # Extract just the slot numbers for slots with defined disks
-    grep -E "^diskId\.[0-9]+=[^=]+" /proc/nmdstat | cut -d'.' -f2 | cut -d'=' -f1
+    # If NMDSTAT_VALUES is empty, populate it first
+    if [ ${#NMDSTAT_VALUES[@]} -eq 0 ]; then
+        get_all_nmdstat_values NMDSTAT_VALUES
+    fi
+
+    local slots=()
+    # Extract slot numbers for keys matching diskId.X with non-empty values
+    for key in "${!NMDSTAT_VALUES[@]}"; do
+        if [[ $key =~ ^diskId\.([0-9]+)$ ]] && [ -n "${NMDSTAT_VALUES[$key]}" ]; then
+            slots+=(${BASH_REMATCH[1]})
+        fi
+    done
+
+    # Sort the slots numerically and output as space-separated list
+    printf "%s\n" "${slots[@]}" | sort -n | tr '\n' ' '
 }
 
 # Format time duration in seconds to a human-readable format (HH:MM:SS)
@@ -233,19 +296,22 @@ show_status() {
     echo "=== NonRAID Array Status ==="
     echo ""
 
-    # Get basic array info
-    local mdstate=$(get_nmdstat_value "mdState")
-    local sblabel=$(get_nmdstat_value "sbLabel")
-    local sbname=$(get_nmdstat_value "sbName")
-    local mdnumdisks=$(get_nmdstat_value "mdNumDisks")
-    local mdnummissing=$(get_nmdstat_value "mdNumMissing")
-    local mdnuminvalid=$(get_nmdstat_value "mdNumInvalid")
+    # Get all values from nmdstat in one go
+    get_all_nmdstat_values NMDSTAT_VALUES
+
+    # Use values from the associative array
+    local mdstate="${NMDSTAT_VALUES[mdState]}"
+    local sblabel="${NMDSTAT_VALUES[sbLabel]}"
+    local sbname="${NMDSTAT_VALUES[sbName]}"
+    local mdnumdisks="${NMDSTAT_VALUES[mdNumDisks]}"
+    local mdnummissing="${NMDSTAT_VALUES[mdNumMissing]}"
+    local mdnuminvalid="${NMDSTAT_VALUES[mdNumInvalid]}"
 
     # Get additional health indicators
-    local mdnumwrong=$(get_nmdstat_value "mdNumWrong")
-    local mdnumdisabled=$(get_nmdstat_value "mdNumDisabled")
-    local mdnumreplaced=$(get_nmdstat_value "mdNumReplaced")
-    local mdnumnew=$(get_nmdstat_value "mdNumNew")
+    local mdnumwrong="${NMDSTAT_VALUES[mdNumWrong]}"
+    local mdnumdisabled="${NMDSTAT_VALUES[mdNumDisabled]}"
+    local mdnumreplaced="${NMDSTAT_VALUES[mdNumReplaced]}"
+    local mdnumnew="${NMDSTAT_VALUES[mdNumNew]}"
 
     # Display array summary
     echo -e "Array State   : $(format_array_state "$mdstate")"
@@ -272,7 +338,7 @@ show_status() {
     # Count how many disks have been imported
     local imported_disks=0
     for slot in $(get_defined_slots); do
-        local rdevname=$(get_nmdstat_value "rdevName.$slot")
+        local rdevname="${NMDSTAT_VALUES[rdevName.$slot]}"
         if [ -n "$rdevname" ] && [ "$rdevname" != "none" ]; then
             imported_disks=$((imported_disks + 1))
         fi
@@ -338,27 +404,27 @@ show_status() {
     local second_parity_size_gb=0
 
     # Check slots 0 and 29 for parity disks
-    local parity_disk_size=$(get_nmdstat_value "diskSize.0")
+    local parity_disk_size="${NMDSTAT_VALUES[diskSize.0]}"
     if [ -n "$parity_disk_size" ] && [ "$parity_disk_size" -gt 0 ]; then
         has_parity=true
         parity_size_gb=$(( (parity_disk_size + 1048575) / 1048576 ))
     fi
 
     # Check P state
-    local parity_disk_status=$(get_nmdstat_value "rdevStatus.0")
+    local parity_disk_status="${NMDSTAT_VALUES[rdevStatus.0]}"
     if [[ "$parity_disk_status" == DISK_NP* ]] || [ "$parity_disk_status" = "DISK_DSBL_NEW" ] || [ "$parity_disk_status" = "DISK_INVALID" ]; then
         # P missing or new, don't count it yet
         has_parity=false
     fi
 
-    local second_parity_disk_size=$(get_nmdstat_value "diskSize.29")
+    local second_parity_disk_size="${NMDSTAT_VALUES[diskSize.29]}"
     if [ -n "$second_parity_disk_size" ] && [ "$second_parity_disk_size" -gt 0 ]; then
         has_second_parity=true
         second_parity_size_gb=$(( (second_parity_disk_size + 1048575) / 1048576 ))
     fi
 
     # Check Q state
-    local second_parity_disk_status=$(get_nmdstat_value "rdevStatus.29")
+    local second_parity_disk_status="${NMDSTAT_VALUES[rdevStatus.29]}"
     if [[ "$second_parity_disk_status" == DISK_NP* ]] || [ "$second_parity_disk_status" = "DISK_DSBL_NEW" ] || [ "$second_parity_disk_status" = "DISK_INVALID" ]; then
         # Q missing or new, don't count it yet
         has_second_parity=false
@@ -367,7 +433,7 @@ show_status() {
     # Count data disks and sum their sizes
     local data_disk_count=0
     for slot in $(seq 1 28); do
-        local disk_size=$(get_nmdstat_value "diskSize.$slot")
+        local disk_size="${NMDSTAT_VALUES[diskSize.$slot]}"
         if [ -n "$disk_size" ] && [ "$disk_size" -gt 0 ]; then
             data_disk_count=$((data_disk_count + 1))
             data_size_gb=$((data_size_gb + (disk_size + 1048575) / 1048576))
@@ -388,8 +454,8 @@ show_status() {
     fi
 
     # Check for reconstruction or check operations
-    local mdresync=$(get_nmdstat_value "mdResync")
-    local mdresyncaction=$(get_nmdstat_value "mdResyncAction")
+    local mdresync="${NMDSTAT_VALUES[mdResync]}"
+    local mdresyncaction="${NMDSTAT_VALUES[mdResyncAction]}"
 
     # Check for pending disk clearing
     if [ "$mdresync" = "0" ] && [ "$mdresyncaction" = "clear" ]; then
@@ -403,10 +469,10 @@ show_status() {
         echo -e "${YELLOW}Start the array and use '${GREEN}nmdctl check${YELLOW}' command to start the reconstruction${NC}"
     # Check for active reconstruction or check operation
     elif [ "$mdresync" != "0" ] && [ -n "$mdresync" ]; then
-        local mdresyncpos=$(get_nmdstat_value "mdResyncPos")
-        local mdresyncsize=$(get_nmdstat_value "mdResyncSize")
-        local mdresyncdt=$(get_nmdstat_value "mdResyncDt")
-        local mdresyncdb=$(get_nmdstat_value "mdResyncDb")
+        local mdresyncpos="${NMDSTAT_VALUES[mdResyncPos]}"
+        local mdresyncsize="${NMDSTAT_VALUES[mdResyncSize]}"
+        local mdresyncdt="${NMDSTAT_VALUES[mdResyncDt]}"
+        local mdresyncdb="${NMDSTAT_VALUES[mdResyncDb]}"
 
         # Calculate progress percentage
         local progress=0
@@ -455,25 +521,25 @@ show_status() {
 
     # Special handling for parity disks
     for idx in 0 29; do
-        local diskname=$(get_nmdstat_value "diskName.$idx")
-        local diskid=$(get_nmdstat_value "diskId.$idx")
-        local rdevstatus=$(get_nmdstat_value "rdevStatus.$idx")
+        local diskname="${NMDSTAT_VALUES[diskName.$idx]}"
+        local diskid="${NMDSTAT_VALUES[diskId.$idx]}"
+        local rdevstatus="${NMDSTAT_VALUES[rdevStatus.$idx]}"
 
         # Always display P, display Q if it has an ID OR it's a newly assigned disk (DISK_*_NEW)
         if [ "$idx" -eq 0 ] || [ -n "$diskid" ] || [[ "$rdevstatus" == DISK_*_NEW ]]; then
-            local disksize=$(get_nmdstat_value "diskSize.$idx")
-            local rdevname=$(get_nmdstat_value "rdevName.$idx")
+            local disksize="${NMDSTAT_VALUES[diskSize.$idx]}"
+            local rdevname="${NMDSTAT_VALUES[rdevName.$idx]}"
 
             # For DISK_NEW, get size from rdevSize instead of diskSize
             if [[ ("$rdevstatus" = "DISK_NEW" || "$rdevstatus" = "DISK_DSBL_NEW") ]] && [ -z "$disksize" -o "$disksize" = "0" ]; then
-                local rdevsize=$(get_nmdstat_value "rdevSize.$idx")
+                local rdevsize="${NMDSTAT_VALUES[rdevSize.$idx]}"
                 if [ -n "$rdevsize" ] && [ "$rdevsize" -gt 0 ]; then
                     disksize="$rdevsize"
                 fi
 
                 # If diskId is empty but rdevId exists, use that
                 if [ -z "$diskid" ]; then
-                    diskid=$(get_nmdstat_value "rdevId.$idx")
+                    diskid="${NMDSTAT_VALUES[rdevId.$idx]}"
                 fi
             fi
 
@@ -530,26 +596,26 @@ show_status() {
 
     # Now list data disks
     for idx in $(seq 1 28); do
-        local diskname=$(get_nmdstat_value "diskName.$idx")
-        local rdevstatus=$(get_nmdstat_value "rdevStatus.$idx")
+        local diskname="${NMDSTAT_VALUES[diskName.$idx]}"
+        local rdevstatus="${NMDSTAT_VALUES[rdevStatus.$idx]}"
 
         # Display disk if it has a name OR it's a newly assigned disk (DISK_NEW)
         if [ -n "$diskname" ] || [ "$rdevstatus" = "DISK_NEW" ]; then
-            local disksize=$(get_nmdstat_value "diskSize.$idx")
-            local diskid=$(get_nmdstat_value "diskId.$idx")
-            local rdevname=$(get_nmdstat_value "rdevName.$idx")
-            local rdevnumerrors=$(get_nmdstat_value "rdevNumErrors.$idx")
+            local disksize="${NMDSTAT_VALUES[diskSize.$idx]}"
+            local diskid="${NMDSTAT_VALUES[diskId.$idx]}"
+            local rdevname="${NMDSTAT_VALUES[rdevName.$idx]}"
+            local rdevnumerrors="${NMDSTAT_VALUES[rdevNumErrors.$idx]}"
 
             # For DISK_NEW, get size from rdevSize instead of diskSize
             if [ "$rdevstatus" = "DISK_NEW" ] && [ -z "$disksize" -o "$disksize" = "0" ]; then
-                local rdevsize=$(get_nmdstat_value "rdevSize.$idx")
+                local rdevsize="${NMDSTAT_VALUES[rdevSize.$idx]}"
                 if [ -n "$rdevsize" ] && [ "$rdevsize" -gt 0 ]; then
                     disksize="$rdevsize"
                 fi
 
                 # If diskId is empty but rdevId exists, use that
                 if [ -z "$diskid" ]; then
-                    diskid=$(get_nmdstat_value "rdevId.$idx")
+                    diskid="${NMDSTAT_VALUES[rdevId.$idx]}"
                 fi
             fi
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -42,6 +42,8 @@ usage() {
     echo "  reload                      Reload nonraid module with specified superblock"
     echo "  check                       Start parity check"
     echo "  nocheck [CANCEL|PAUSE]      Stop parity check (CANCEL or PAUSE)"
+    echo "  mount [MOUNTPREFIX]         Mount all active data disks (default prefix: /mnt/disk)"
+    echo "  unmount                     Unmount all active data disks"
     echo ""
     echo "Global Options:"
     echo "  -s, --super PATH            Superblock file path to use when loading the module (default: $DEFAULT_SUPERBLOCK)"
@@ -2053,6 +2055,245 @@ reload_module() {
     return 0
 }
 
+# Mount all active data disks with identified filesystems
+mount_array_disks() {
+    check_root
+
+    local mount_prefix="${1:-/mnt/disk}"
+
+    # Check if array is running
+    if ! check_nmdstat_exists; then
+        return 1
+    fi
+
+    # Get all values from nmdstat
+    get_all_nmdstat_values NMDSTAT_VALUES
+
+    local mdstate="${NMDSTAT_VALUES[mdState]}"
+    if [ "$mdstate" != "STARTED" ]; then
+        echo -e "${RED}Error: Array must be started before mounting disks${NC}"
+        echo -e "Current array state: $mdstate"
+        echo -e "Start the array with: ${YELLOW}nmdctl start${NC}"
+        return 1
+    fi
+
+    echo "=== Mounting NonRAID Array Disks ==="
+    echo ""
+    echo "Using mount prefix: $mount_prefix"
+    echo ""
+
+    local mounted_count=0
+    local skipped_count=0
+    local error_count=0
+
+    # Get all defined slots
+    local defined_slots=$(get_defined_slots)
+
+    # Process data disks (skip parity slots 0 and 29)
+    for slot in $defined_slots; do
+        # Skip parity disks (slots 0 and 29)
+        if [ "$slot" = "0" ] || [ "$slot" = "29" ]; then
+            continue
+        fi
+
+        local rdevname="${NMDSTAT_VALUES[rdevName.$slot]}"
+        local rdevstatus="${NMDSTAT_VALUES[rdevStatus.$slot]}"
+        local diskname="${NMDSTAT_VALUES[diskName.$slot]}"
+        local diskid="${NMDSTAT_VALUES[diskId.$slot]}"
+
+        # Skip slots with no device or not in DISK_OK status
+        if [ -z "$rdevname" ] || [ "$rdevname" = "none" ] || [ "$rdevstatus" != "DISK_OK" ]; then
+            continue
+        fi
+
+        # Get filesystem type and current mountpoint
+        local device="/dev/${diskname}"
+        local fs_type=$(get_fs_type "$device")
+        local current_mountpoint=$(get_mountpoint "$diskname" "$fs_type")
+
+        # Skip if no filesystem or already mounted
+        if [ -z "$fs_type" ] || [ "$fs_type" = "unknown" ]; then
+            echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}No filesystem detected${NC}"
+            skipped_count=$((skipped_count + 1))
+            continue
+        elif [ "$current_mountpoint" != "unmounted" ]; then
+            echo -e "Slot $slot (${BLUE}${diskname}${NC}): Already mounted at ${GREEN}$current_mountpoint${NC}"
+            skipped_count=$((skipped_count + 1))
+            continue
+        fi
+
+        # Handle mounting based on filesystem type
+        case "$fs_type" in
+            "zfs")
+                # For ZFS, we need to import the pool
+                local pool_name="disk${slot}"
+                echo -n "Slot $slot (${diskname}): Importing ZFS pool $pool_name... "
+
+                if zpool import -d "$device" "$pool_name" 2>/dev/null; then
+                    echo -e "${GREEN}SUCCESS${NC}"
+                    mounted_count=$((mounted_count + 1))
+                else
+                    echo -e "${RED}FAILED${NC}"
+                    error_count=$((error_count + 1))
+                fi
+                ;;
+
+            "xfs"|"ext4"|"ext3"|"ext2"|"btrfs"|*)
+                # Standard filesystems
+                local mountpoint="${mount_prefix}${slot}"
+
+                # Create mountpoint if it doesn't exist
+                if [ ! -d "$mountpoint" ]; then
+                    mkdir -p "$mountpoint"
+                fi
+
+                echo -n "Slot $slot (${diskname}): Mounting $fs_type to $mountpoint... "
+
+                if mount "$device" "$mountpoint" 2>/dev/null; then
+                    echo -e "${GREEN}SUCCESS${NC}"
+                    mounted_count=$((mounted_count + 1))
+                else
+                    echo -e "${RED}FAILED${NC}"
+                    error_count=$((error_count + 1))
+                fi
+                ;;
+        esac
+    done
+
+    echo ""
+    echo "Mount summary:"
+    echo -e "  ${GREEN}$mounted_count${NC} disks mounted successfully"
+    echo -e "  ${BLUE}$skipped_count${NC} disks skipped (already mounted or no filesystem)"
+    if [ $error_count -gt 0 ]; then
+        echo -e "  ${RED}$error_count${NC} disks failed to mount"
+        return 1
+    fi
+
+    return 0
+}
+
+# Unmount all active data disks
+unmount_array_disks() {
+    check_root
+
+    # Check if array is running
+    if ! check_nmdstat_exists; then
+        return 1
+    fi
+
+    # Get all values from nmdstat
+    get_all_nmdstat_values NMDSTAT_VALUES
+
+    local mdstate="${NMDSTAT_VALUES[mdState]}"
+    if [ "$mdstate" != "STARTED" ]; then
+        echo -e "${RED}Error: Array must be started to unmount disks properly${NC}"
+        echo -e "Current array state: $mdstate"
+        return 1
+    fi
+
+    echo "=== Unmounting NonRAID Array Disks ==="
+    echo ""
+
+    local unmounted_count=0
+    local skipped_count=0
+    local error_count=0
+
+    # Get all defined slots
+    local defined_slots=$(get_defined_slots)
+
+    # Process data disks (skip parity slots 0 and 29)
+    for slot in $defined_slots; do
+        # Skip parity disks (slots 0 and 29)
+        if [ "$slot" = "0" ] || [ "$slot" = "29" ]; then
+            continue
+        fi
+
+        local rdevname="${NMDSTAT_VALUES[rdevName.$slot]}"
+        local rdevstatus="${NMDSTAT_VALUES[rdevStatus.$slot]}"
+        local diskname="${NMDSTAT_VALUES[diskName.$slot]}"
+        local diskid="${NMDSTAT_VALUES[diskId.$slot]}"
+
+        # Skip slots with no device or not in DISK_OK status
+        if [ -z "$rdevname" ] || [ "$rdevname" = "none" ] || [ "$rdevstatus" != "DISK_OK" ]; then
+            continue
+        fi
+
+        # Get filesystem type and current mountpoint
+        local device="/dev/${diskname}"
+        local fs_type=$(get_fs_type "$device")
+        local current_mountpoint=$(get_mountpoint "$diskname" "$fs_type")
+
+        # Skip if no filesystem or already unmounted
+        if [ -z "$fs_type" ] || [ "$fs_type" = "unknown" ]; then
+            echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}No filesystem detected${NC}"
+            skipped_count=$((skipped_count + 1))
+            continue
+        elif [ "$current_mountpoint" = "unmounted" ]; then
+            echo -e "Slot $slot (${BLUE}${diskname}${NC}): Already unmounted"
+            skipped_count=$((skipped_count + 1))
+            continue
+        fi
+
+        # Handle unmounting based on filesystem type
+        case "$fs_type" in
+            "zfs")
+                # For ZFS, we need to export the pool
+                # Get the pool name that contains this device
+                local pool_name=""
+                if command -v zpool >/dev/null 2>&1; then
+                    pool_name=$(zpool list -H -o name,health | awk '{print $1}' | while read -r pool; do
+                        if zpool status "$pool" 2>/dev/null | grep -q "$diskname"; then
+                            echo "$pool"
+                            break
+                        fi
+                    done)
+                fi
+
+                if [ -n "$pool_name" ]; then
+                    echo -n "Slot $slot (${diskname}): Exporting ZFS pool $pool_name... "
+                    if zpool export "$pool_name" 2>/dev/null; then
+                        echo -e "${GREEN}SUCCESS${NC}"
+                        unmounted_count=$((unmounted_count + 1))
+                    else
+                        echo -e "${RED}FAILED${NC}"
+                        error_count=$((error_count + 1))
+                    fi
+                else
+                    echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}ZFS pool not found${NC}"
+                    skipped_count=$((skipped_count + 1))
+                fi
+                ;;
+
+            "xfs"|"ext4"|"ext3"|"ext2"|"btrfs"|*)
+                echo -n "Slot $slot (${diskname}): Unmounting from $current_mountpoint... "
+
+                # Try unmounting with increasing force if needed
+                if umount "$current_mountpoint" 2>/dev/null ||
+                   umount -f "$current_mountpoint" 2>/dev/null; then
+                    echo -e "${GREEN}SUCCESS${NC}"
+                    unmounted_count=$((unmounted_count + 1))
+                else
+                    echo -e "${RED}FAILED${NC} (Device may be busy)"
+                    echo -e "  You can check what's using it with: ${YELLOW}lsof $current_mountpoint${NC}"
+                    error_count=$((error_count + 1))
+                fi
+                ;;
+        esac
+    done
+
+    echo ""
+    echo "Unmount summary:"
+    echo -e "  ${GREEN}$unmounted_count${NC} disks unmounted successfully"
+    echo -e "  ${BLUE}$skipped_count${NC} disks skipped (already unmounted or no filesystem)"
+    if [ $error_count -gt 0 ]; then
+        echo -e "  ${RED}$error_count${NC} disks failed to unmount"
+        echo -e "${YELLOW}Note: Use 'fuser -m <mountpoint>' to see which processes are using the disk${NC}"
+        return 1
+    fi
+
+    return 0
+}
+
 # Main entry point
 main() {
     # Check for at least one argument
@@ -2128,6 +2369,12 @@ main() {
             ;;
         "nocheck")
             stop_check "$1"
+            ;;
+        "mount")
+            mount_array_disks "$1"
+            ;;
+        "unmount")
+            unmount_array_disks
             ;;
         *)
             echo -e "${RED}Error: Unknown command '$command'${NC}"

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1,7 +1,9 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 #
 # nmdctl - NonRAID array management utility
 #
+
 
 # Check for bash version 4 or higher (needed for associative arrays)
 if ((BASH_VERSINFO[0] < 4)); then
@@ -59,8 +61,7 @@ check_root() {
 # Run a command via nmdcmd
 run_nmd_command() {
     check_root
-    echo "$1" > /proc/nmdcmd
-    if [ $? -ne 0 ]; then
+    if ! echo "$1" > /proc/nmdcmd; then
         echo -e "${RED}Error: Failed to run command '$1'${NC}"
         return 1
     fi
@@ -73,7 +74,7 @@ check_module_loaded() {
     local is_create_command=0
 
     # Check if we're being called as part of the create command
-    local call_stack="${FUNCNAME[@]}"
+    local call_stack="${FUNCNAME[*]}"
     if [[ "$call_stack" == *"create_array"* ]]; then
         is_create_command=1
     fi
@@ -136,7 +137,7 @@ check_nmdstat_exists() {
     if [ ! -f /proc/nmdstat ]; then
         # Clear the NMDSTAT_VALUES array since /proc/nmdstat doesn't exist
         for key in "${!NMDSTAT_VALUES[@]}"; do
-            unset NMDSTAT_VALUES["$key"]
+            unset 'NMDSTAT_VALUES["$key"]'
         done
 
         # Try to load the module first if it's not loaded
@@ -162,7 +163,7 @@ get_all_nmdstat_values() {
 
     # Clear the array first
     for key in "${!array_ref[@]}"; do
-        unset array_ref["$key"]
+        unset 'array_ref["$key"]'
     done
 
     # Read all values from /proc/nmdstat
@@ -263,7 +264,7 @@ get_defined_slots() {
     # Extract slot numbers for keys matching diskId.X with non-empty values
     for key in "${!NMDSTAT_VALUES[@]}"; do
         if [[ $key =~ ^diskId\.([0-9]+)$ ]] && [ -n "${NMDSTAT_VALUES[$key]}" ]; then
-            slots+=(${BASH_REMATCH[1]})
+            slots+=("${BASH_REMATCH[1]}")
         fi
     done
 
@@ -335,7 +336,7 @@ determine_array_health() {
     done
 
     # Check for critical error conditions first
-    if [ "$mdstate" = "ERROR:"* ]; then
+    if [[ "$mdstate" = "ERROR:"* ]]; then
         health_status="${RED}ERROR${NC}"
         health_details="Array is in ERROR state"
     # Check if this is a new array
@@ -594,7 +595,7 @@ display_disk_entry() {
     if [ -n "$rdevnumerrors" ] && [ "$rdevnumerrors" -gt 0 ]; then
         status_formatted="$status_formatted ($rdevnumerrors errs)"
         # Account for the extra text in the visible length
-        visible_length=$((visible_length + ${#rdevnumerrors} + 7))
+        visible_length=$((visible_length + ${#rdevnumerrors} + 8))
     fi
 
     # Fix alignment with proper field widths - split into parts to handle color codes
@@ -778,7 +779,7 @@ get_mountpoint() {
                     # Check if the pool is mounted
                     local zfs_mounts=$(zfs list -H -o name,mountpoint | grep -v "none$")
                     # Start with the pool itself
-                    local found_mountpoint=$(echo "$zfs_mounts" | grep "^$pool[[:blank:]]" | awk '{print $2}' | head -1)
+                    local found_mountpoint=$(echo "$zfs_mounts" | grep "^${pool}[[:blank:]]" | awk '{print $2}' | head -1)
 
                     if [ -n "$found_mountpoint" ] && [ "$found_mountpoint" != "none" ]; then
                         mountpoint="$found_mountpoint"
@@ -878,30 +879,6 @@ get_disk_size_kb() {
     fi
 }
 
-# Get disk ID from /dev/disk/by-id
-get_disk_id() {
-    local device="$1"
-
-    # Get device name without /dev/
-    local devname=$(basename "$device")
-
-    # Use a safer approach to find the matching disk ID
-    local disk_id=""
-    if [ -d "/dev/disk/by-id" ]; then
-        for id_path in /dev/disk/by-id/*; do
-            if [ -L "$id_path" ] && [[ "$id_path" != *-part* ]]; then
-                local link_target=$(readlink -f "$id_path")
-                if [ "$(basename "$link_target")" = "$devname" ]; then
-                    disk_id=$(basename "$id_path")
-                    break
-                fi
-            fi
-        done
-    fi
-
-    echo "$disk_id"
-}
-
 # Find disk device name matching the ID in nmdstat
 find_matching_disk() {
     local disk_id="$1"
@@ -995,11 +972,9 @@ import_disks() {
                     # Get the configured size from nmdstat
                     local configured_size=$(get_nmdstat_value "diskSize.$slot")
                     local size_to_use="$disk_size"
-                    local size_mismatch=0
 
                     # If we have a configured size and it differs from actual size
                     if [ -n "$configured_size" ] && [ "$configured_size" -gt 0 ] && [ "$configured_size" -ne "$disk_size" ]; then
-                        size_mismatch=1
                         echo -e "${YELLOW}Warning: Size mismatch for disk in slot $slot${NC}"
                         echo -e "  Partition size: $disk_size KB"
                         echo -e "  Expected size : $configured_size KB"
@@ -1104,7 +1079,6 @@ start_array() {
     mdstate=$(get_nmdstat_value "mdState")
 
     # Check if all defined disks have been imported
-    local defined_slots=$(get_defined_slots_count)
     local imported_disks=0
     local missing_slots=()
 
@@ -1273,7 +1247,7 @@ list_available_devices() {
         fi
 
         # Check if the device has exactly one partition
-        local partition_count=$(ls -l ${dev}* 2>/dev/null | grep -E "${dev}[0-9]+" | wc -l)
+        local partition_count=$(ls -l ${dev}* 2>/dev/null | grep -cE "${dev}[0-9]+")
         if [ "$partition_count" -eq 1 ]; then
             # Get the partition device
             local partition=""
@@ -1453,7 +1427,8 @@ create_array() {
 
             if [ -n "$slot" ]; then
                 # Check if slot is already assigned
-                if [[ " ${assigned_slots[@]} " =~ " $slot " ]]; then
+                # shellcheck disable=SC2076
+                if [[ " ${assigned_slots[*]} " =~ " $slot " ]]; then
                     echo -e "${RED}Error: Slot $slot is already assigned. Please choose another slot.${NC}"
                     continue
                 fi
@@ -1651,7 +1626,8 @@ add_disk() {
 
     # Then, determine which slots are available
     for slot in $(seq 1 28); do
-        if ! [[ " ${used_slots[@]} " =~ " $slot " ]]; then
+        # shellcheck disable=SC2076
+        if ! [[ " ${used_slots[*]} " =~ " $slot " ]]; then
             available_slots+=("$slot")
         fi
     done
@@ -1660,11 +1636,11 @@ add_disk() {
     local has_parity=false
     local has_second_parity=false
 
-    if [[ " ${used_slots[@]} " =~ " 0 " ]]; then
+    if [[ " ${used_slots[*]} " =~ " 0 " ]]; then
         has_parity=true
     fi
 
-    if [[ " ${used_slots[@]} " =~ " 29 " ]]; then
+    if [[ " ${used_slots[*]} " =~ " 29 " ]]; then
         has_second_parity=true
     fi
 
@@ -1794,7 +1770,8 @@ add_disk() {
         fi
 
         # Check if selected slot is available
-        if ! [[ " ${available_slots[@]} " =~ " $choice " ]]; then
+        # shellcheck disable=SC2076
+        if ! [[ " ${available_slots[*]} " =~ " $choice " ]]; then
             echo -e "${RED}Invalid slot. Please choose from available slots: ${available_slots[*]}.${NC}"
             continue
         fi
@@ -2021,8 +1998,7 @@ reload_module() {
     # Check if module is loaded
     if ! lsmod | grep -q nonraid; then
         echo -e "${YELLOW}NonRAID module not loaded. Loading with superblock: $superblock${NC}"
-        modprobe nonraid super="$superblock"
-        if [ $? -ne 0 ]; then
+        if ! modprobe nonraid super="$superblock"; then
             echo -e "${RED}Error: Failed to load nonraid module${NC}"
             return 1
         fi
@@ -2048,8 +2024,7 @@ reload_module() {
 
     # Unload module
     echo "Unloading nonraid module..."
-    modprobe -r nonraid
-    if [ $? -ne 0 ]; then
+    if ! modprobe -r nonraid; then
         echo -e "${RED}Error: Failed to unload nonraid module. It may be in use.${NC}"
         return 1
     fi
@@ -2059,8 +2034,7 @@ reload_module() {
 
     # Load module with specified superblock
     echo "Loading nonraid module with superblock: $superblock"
-    modprobe nonraid super="$superblock"
-    if [ $? -ne 0 ]; then
+    if ! modprobe nonraid super="$superblock"; then
         echo -e "${RED}Error: Failed to reload nonraid module${NC}"
         return 1
     fi

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -287,33 +287,13 @@ format_time_duration() {
     fi
 }
 
-# Show current array status
-show_status() {
-    if ! check_nmdstat_exists; then
-        return 1
-    fi
-
-    echo "=== NonRAID Array Status ==="
-    echo ""
-
-    # Get all values from nmdstat in one go
-    get_all_nmdstat_values NMDSTAT_VALUES
-
-    # Use values from the associative array
+# Show array summary information (state, label, superblock, disks present)
+show_array_summary() {
     local mdstate="${NMDSTAT_VALUES[mdState]}"
     local sblabel="${NMDSTAT_VALUES[sbLabel]}"
     local sbname="${NMDSTAT_VALUES[sbName]}"
     local mdnumdisks="${NMDSTAT_VALUES[mdNumDisks]}"
-    local mdnummissing="${NMDSTAT_VALUES[mdNumMissing]}"
-    local mdnuminvalid="${NMDSTAT_VALUES[mdNumInvalid]}"
 
-    # Get additional health indicators
-    local mdnumwrong="${NMDSTAT_VALUES[mdNumWrong]}"
-    local mdnumdisabled="${NMDSTAT_VALUES[mdNumDisabled]}"
-    local mdnumreplaced="${NMDSTAT_VALUES[mdNumReplaced]}"
-    local mdnumnew="${NMDSTAT_VALUES[mdNumNew]}"
-
-    # Display array summary
     echo -e "Array State   : $(format_array_state "$mdstate")"
     [ -n "$sblabel" ] && echo -e "Array Label   : $sblabel"
 
@@ -327,8 +307,18 @@ show_status() {
     fi
 
     echo -e "Disks Present : $mdnumdisks"
+}
 
-    # Check array health status based on various conditions
+# Determine array health status based on various conditions
+determine_array_health() {
+    local mdstate="${NMDSTAT_VALUES[mdState]}"
+    local mdnummissing="${NMDSTAT_VALUES[mdNumMissing]}"
+    local mdnuminvalid="${NMDSTAT_VALUES[mdNumInvalid]}"
+    local mdnumwrong="${NMDSTAT_VALUES[mdNumWrong]}"
+    local mdnumdisabled="${NMDSTAT_VALUES[mdNumDisabled]}"
+    local mdnumreplaced="${NMDSTAT_VALUES[mdNumReplaced]}"
+    local mdnumnew="${NMDSTAT_VALUES[mdNumNew]}"
+
     local health_status=""
     local health_details=""
 
@@ -395,8 +385,40 @@ show_status() {
     else
         echo ""
     fi
+}
 
-    # Calculate array size and parity information
+# Show current array status
+show_status() {
+    if ! check_nmdstat_exists; then
+        return 1
+    fi
+
+    echo "=== NonRAID Array Status ==="
+    echo ""
+
+    # Get all values from nmdstat in one go
+    get_all_nmdstat_values NMDSTAT_VALUES
+
+    # Show array summary (state, label, superblock, disks present)
+    show_array_summary
+
+    # Show array health status
+    determine_array_health
+
+    # Show array size and parity information
+    show_array_size_and_parity
+
+    # Show resync operation status if any
+    show_resync_status
+
+    # Show disk status
+    show_disk_status
+
+    return 0
+}
+
+# Display array size and parity information
+show_array_size_and_parity() {
     local has_parity=false
     local has_second_parity=false
     local data_size_gb=0
@@ -452,8 +474,10 @@ show_status() {
     else
         echo -e "${YELLOW}No Parity${NC}"
     fi
+}
 
-    # Check for reconstruction or check operations
+# Display resync operation status (reconstruction, clearing, check)
+show_resync_status() {
     local mdresync="${NMDSTAT_VALUES[mdResync]}"
     local mdresyncaction="${NMDSTAT_VALUES[mdResyncAction]}"
 
@@ -511,8 +535,74 @@ show_status() {
         echo -e "Elapsed Time  : $elapsed_formatted"
         echo -e "ETA           : $eta_formatted"
     fi
+}
 
-    # List all disks in the array
+# Calculate visible length of disk status for alignment
+get_status_visible_length() {
+    local status="$1"
+
+    case "$status" in
+        "DISK_OK")
+            echo "2" # "OK"
+            ;;
+        "DISK_INVALID")
+            echo "7" # "INVALID"
+            ;;
+        "DISK_NP_MISSING")
+            echo "7" # "MISSING"
+            ;;
+        "DISK_WRONG")
+            echo "5" # "WRONG"
+            ;;
+        "DISK_DSBL"|"DISK_NP_DSBL"|"DISK_DSBL_NEW")
+            echo "8" # "DISABLED"
+            ;;
+        "DISK_NEW")
+            echo "3" # "NEW"
+            ;;
+        *)
+            echo "${#status}" # Use raw length as fallback
+            ;;
+    esac
+}
+
+# Format and display a single disk entry in the array
+display_disk_entry() {
+    local idx="$1"
+    local slottype="$2"
+    local disksize="$3"
+    local diskid="$4"
+    local rdevname="$5"
+    local rdevstatus="$6"
+    local rdevnumerrors="${7:-0}"
+
+    # Convert size to GB
+    local sizegb=0
+    if [ -n "$disksize" ] && [ "$disksize" -gt 0 ]; then
+        sizegb=$(( (disksize + 1048575) / 1048576 ))
+    fi
+
+    local status_formatted=$(format_disk_status "$rdevstatus")
+
+    # Map status to visible text length for alignment
+    local visible_length=$(get_status_visible_length "$rdevstatus")
+
+    # Add indicator for disk errors
+    if [ -n "$rdevnumerrors" ] && [ "$rdevnumerrors" -gt 0 ]; then
+        status_formatted="$status_formatted ($rdevnumerrors errs)"
+        # Account for the extra text in the visible length
+        visible_length=$((visible_length + ${#rdevnumerrors} + 7))
+    fi
+
+    # Fix alignment with proper field widths - split into parts to handle color codes
+    printf "%-4s  " "${slottype:-$idx}"
+    printf "%s" "$status_formatted"
+    printf "%$((21 - visible_length))s" " " # Use visible length for padding
+    printf "%-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+}
+
+# Display all disks in the array
+show_disk_status() {
     echo ""
     echo "=== Disk Status ==="
     echo ""
@@ -543,12 +633,6 @@ show_status() {
                 fi
             fi
 
-            # Convert size to GB
-            local sizegb=0
-            if [ -n "$disksize" ] && [ "$disksize" -gt 0 ]; then
-                sizegb=$(( (disksize + 1048575) / 1048576 ))
-            fi
-
             local slottype=""
             if [ "$idx" -eq 0 ]; then
                 slottype="P"
@@ -557,39 +641,7 @@ show_status() {
             fi
 
             if [ -n "$rdevstatus" ]; then
-                local status_formatted=$(format_disk_status "$rdevstatus")
-
-                # Map status to visible text length for alignment
-                local visible_length=0
-                case "$rdevstatus" in
-                    "DISK_OK")
-                        visible_length=2 # "OK"
-                        ;;
-                    "DISK_INVALID")
-                        visible_length=7 # "INVALID"
-                        ;;
-                    "DISK_NP_MISSING")
-                        visible_length=7 # "MISSING"
-                        ;;
-                    "DISK_WRONG")
-                        visible_length=5 # "WRONG"
-                        ;;
-                    "DISK_DSBL"|"DISK_NP_DSBL"|"DISK_DSBL_NEW")
-                        visible_length=8 # "DISABLED"
-                        ;;
-                    "DISK_NEW")
-                        visible_length=3 # "NEW"
-                        ;;
-                    *)
-                        visible_length=${#rdevstatus} # Use raw length as fallback
-                        ;;
-                esac
-
-                # Fix alignment with proper field widths - need special handling for color codes
-                printf "%-4s  " "$slottype"
-                printf "%s" "$status_formatted"
-                printf "%$((21 - visible_length))s" " " # Use visible length for padding
-                printf "%-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+                display_disk_entry "$idx" "$slottype" "$disksize" "$diskid" "$rdevname" "$rdevstatus"
             fi
         fi
     done
@@ -619,52 +671,7 @@ show_status() {
                 fi
             fi
 
-            # Convert size to GB
-            local sizegb=0
-            if [ -n "$disksize" ] && [ "$disksize" -gt 0 ]; then
-                sizegb=$(( (disksize + 1048575) / 1048576 ))
-            fi
-
-            local status_formatted=$(format_disk_status "$rdevstatus")
-
-            # Map status to visible text length for alignment
-            local visible_length=0
-            case "$rdevstatus" in
-                "DISK_OK")
-                    visible_length=2 # "OK"
-                    ;;
-                "DISK_INVALID")
-                    visible_length=7 # "INVALID"
-                    ;;
-                "DISK_NP_MISSING")
-                    visible_length=7 # "MISSING"
-                    ;;
-                "DISK_WRONG")
-                    visible_length=5 # "WRONG"
-                    ;;
-                "DISK_DSBL"|"DISK_NP_DSBL"|"DISK_DSBL_NEW")
-                    visible_length=8 # "DISABLED"
-                    ;;
-                "DISK_NEW")
-                    visible_length=3 # "NEW"
-                    ;;
-                *)
-                    visible_length=${#rdevstatus} # Use raw length as fallback
-                    ;;
-            esac
-
-            # Add indicator for disk errors
-            if [ -n "$rdevnumerrors" ] && [ "$rdevnumerrors" -gt 0 ]; then
-                status_formatted="$status_formatted ($rdevnumerrors errs)"
-                # Account for the extra text in the visible length
-                visible_length=$((visible_length + ${#rdevnumerrors} + 7))
-            fi
-
-            # Fix alignment with proper field widths - split into parts to handle color codes
-            printf "%-4s  " "$idx"
-            printf "%s" "$status_formatted"
-            printf "%$((21 - visible_length))s" " " # Use visible length for padding
-            printf "%-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+            display_disk_entry "$idx" "" "$disksize" "$diskid" "$rdevname" "$rdevstatus" "$rdevnumerrors"
         fi
     done
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -575,6 +575,8 @@ display_disk_entry() {
     local rdevname="$5"
     local rdevstatus="$6"
     local rdevnumerrors="${7:-0}"
+    local diskname="$8"
+    local mdstate="$9"
 
     # Convert size to GB
     local sizegb=0
@@ -598,16 +600,31 @@ display_disk_entry() {
     printf "%-4s  " "${slottype:-$idx}"
     printf "%s" "$status_formatted"
     printf "%$((21 - visible_length))s" " " # Use visible length for padding
-    printf "%-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+
+    if [ "$mdstate" = "STARTED" ]; then
+        # Include disk name column when array is started
+        printf "%-10s  %-14s  %-8s  %s\n" "${rdevname:-none}" "${diskname:-${slottype:-$idx}}" "$sizegb" "$diskid"
+    else
+        # Original format without disk name
+        printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+    fi
 }
 
 # Display all disks in the array
 show_disk_status() {
+    local mdstate="${NMDSTAT_VALUES[mdState]}"
+
     echo ""
     echo "=== Disk Status ==="
     echo ""
-    echo -e "Slot  Status               Device            Size(GB)  Drive ID"
-    echo -e "----  -------------------  ----------------  --------  -------------------------------------"
+
+    if [ "$mdstate" = "STARTED" ]; then
+        echo -e "Slot  Status               Device      Disk Name       Size(GB)  Drive ID"
+        echo -e "----  -------------------  ----------  -------------   --------  -------------------------------------"
+    else
+        echo -e "Slot  Status               Device      Size(GB)  Drive ID"
+        echo -e "----  -------------------  ----------  --------  -------------------------------------"
+    fi
 
     # Special handling for parity disks
     for idx in 0 29; do
@@ -619,6 +636,7 @@ show_disk_status() {
         if [ "$idx" -eq 0 ] || [ -n "$diskid" ] || [[ "$rdevstatus" == DISK_*_NEW ]]; then
             local disksize="${NMDSTAT_VALUES[diskSize.$idx]}"
             local rdevname="${NMDSTAT_VALUES[rdevName.$idx]}"
+            local rdevnumerrors="${NMDSTAT_VALUES[rdevNumErrors.$idx]}"
 
             # For DISK_NEW, get size from rdevSize instead of diskSize
             if [[ ("$rdevstatus" = "DISK_NEW" || "$rdevstatus" = "DISK_DSBL_NEW") ]] && [ -z "$disksize" -o "$disksize" = "0" ]; then
@@ -641,7 +659,7 @@ show_disk_status() {
             fi
 
             if [ -n "$rdevstatus" ]; then
-                display_disk_entry "$idx" "$slottype" "$disksize" "$diskid" "$rdevname" "$rdevstatus"
+                display_disk_entry "$idx" "$slottype" "$disksize" "$diskid" "$rdevname" "$rdevstatus" "$rdevnumerrors" "$diskname" "$mdstate"
             fi
         fi
     done
@@ -671,7 +689,7 @@ show_disk_status() {
                 fi
             fi
 
-            display_disk_entry "$idx" "" "$disksize" "$diskid" "$rdevname" "$rdevstatus" "$rdevnumerrors"
+            display_disk_entry "$idx" "" "$disksize" "$diskid" "$rdevname" "$rdevstatus" "$rdevnumerrors" "$diskname" "$mdstate"
         fi
     done
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -604,30 +604,29 @@ display_disk_entry() {
 
     if [ "$mdstate" = "STARTED" ]; then
         local mountpoint=""
+        local usage="-"
+        local fs_type=""
 
         # Get filesystem type and mountpoint for data disks when array is started
         if [ -n "$diskname" ] && [ "$diskname" != "none" ]; then
-            # For data disks, get the filesystem type
-            if [[ "$idx" != "0" && "$idx" != "29" ]]; then
-                # Check if device exists before calling blkid
-                if [ -b "/dev/$diskname" ]; then
-                    fs_type=$(get_fs_type "/dev/$diskname")
-                    # Get mountpoint if we have a filesystem
-                    if [ -n "$fs_type" ] && [ "$fs_type" != "unknown" ]; then
-                        mountpoint=$(get_mountpoint "$diskname" "$fs_type")
-                    else
-                        mountpoint="unmounted"
+            # Check if device exists before calling blkid
+            if [ -b "/dev/$diskname" ]; then
+                fs_type=$(get_fs_type "/dev/$diskname")
+                # Get mountpoint if we have a filesystem
+                if [ -n "$fs_type" ] && [ "$fs_type" != "unknown" ]; then
+                    mountpoint=$(get_mountpoint "$diskname" "$fs_type")
+                    # Get usage percentage if mounted
+                    if [ "$mountpoint" != "unmounted" ] && [ "$mountpoint" != "-" ]; then
+                        usage=$(get_fs_usage "$mountpoint" "$fs_type")
                     fi
+                else
+                    mountpoint="unmounted"
                 fi
-            else
-                # For parity disks, use slot type (P or Q)
-                fs_type="${slottype:-}"
-                mountpoint="-"
             fi
         fi
 
-        # Include disk name, filesystem, and mountpoint columns when array is started
-        printf "%-10s  %-8s  %-14s  %-8s  %-16s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-}" "${mountpoint:-unmounted}" "$diskid"
+        # Include disk name, filesystem, mountpoint and usage columns when array is started
+        printf "%-10s  %-8s  %-14s  %-8s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
     else
         # Original format without disk name and filesystem
         printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
@@ -643,8 +642,8 @@ show_disk_status() {
     echo ""
 
     if [ "$mdstate" = "STARTED" ]; then
-        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Mountpoint        Drive ID"
-        echo -e "----  -------------------  ----------  --------  -------------   --------  ---------------   -------------------------------------"
+        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Mountpoint        Usage     Drive ID"
+        echo -e "----  -------------------  ----------  --------  -------------   --------  ---------------   --------  -------------------------------------"
     else
         echo -e "Slot  Status               Device      Size(GB)  Drive ID"
         echo -e "----  -------------------  ----------  --------  -------------------------------------"
@@ -798,6 +797,51 @@ get_mountpoint() {
     esac
 
     echo "$mountpoint"
+    return 0
+}
+
+# Get filesystem usage percentage
+get_fs_usage() {
+    local mountpoint="$1"
+    local fs_type="$2"
+
+    # If not mounted or invalid mountpoint, return empty
+    if [ "$mountpoint" = "unmounted" ] || [ "$mountpoint" = "-" ] || [ ! -d "$mountpoint" ]; then
+        echo "-"
+        return 0
+    fi
+
+    # Handle different filesystem types
+    case "$fs_type" in
+        "zfs")
+            # For ZFS, we need to use zfs command to get usage
+            if command -v zfs >/dev/null 2>&1; then
+                # Extract pool/dataset name from the mountpoint
+                local dataset=$(zfs list -H -o name,mountpoint | grep "[[:space:]]$mountpoint$" | awk '{print $1}' | head -1)
+                if [ -n "$dataset" ]; then
+                    # Use zfs get to get the percentage directly
+                    local usage=$(zpool list -H -o cap "$dataset" 2>/dev/null)
+                    if [ -n "$usage" ]; then
+                        echo "$usage"
+                        return 0
+                    fi
+                fi
+            fi
+            ;;
+
+        *)
+            # Generic approach using df for standard filesystems
+            if command -v df >/dev/null 2>&1; then
+                local usage=$(df -h "$mountpoint" 2>/dev/null | tail -n 1 | awk '{ print $5 }')
+                if [ -n "$usage" ]; then
+                    echo "$usage"
+                    return 0
+                fi
+            fi
+            ;;
+    esac
+
+    echo "-"
     return 0
 }
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -22,6 +22,13 @@ NC='\033[0m' # No Color
 DEFAULT_SUPERBLOCK="/nonraid.dat"
 SUPERBLOCK_PATH=""
 
+# LUKS keyfile path
+LUKS_KEYFILE="/etc/nonraid/luks-keyfile"
+
+# verbose & unattended
+VERBOSE=0
+UNATTENDED=0
+
 # Global associative array for nmdstat values
 declare -A NMDSTAT_VALUES
 
@@ -619,6 +626,7 @@ display_disk_entry() {
         local usage="-"
         local fs_type=""
 
+        [ -n "$slottype" ] && mountpoint="-"
         # Get filesystem type and mountpoint for data disks when array is started
         if [ -n "$diskname" ] && [ "$diskname" != "none" ]; then
             # Check if device exists before calling blkid
@@ -638,7 +646,7 @@ display_disk_entry() {
         fi
 
         # Include disk name, filesystem, mountpoint and usage columns when array is started
-        printf "%-10s  %-8s  %-14s  %-8s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
+        printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
     else
         # Original format without disk name and filesystem
         printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
@@ -654,8 +662,8 @@ show_disk_status() {
     echo ""
 
     if [ "$mdstate" = "STARTED" ]; then
-        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Mountpoint        Usage     Drive ID"
-        echo -e "----  -------------------  ----------  --------  -------------   --------  ---------------   --------  -------------------------------------"
+        echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage     Drive ID"
+        echo -e "----  -------------------  ----------  --------  ----------  ------------  ---------------   --------  -------------------------------------"
     else
         echo -e "Slot  Status               Device      Size(GB)  Drive ID"
         echo -e "----  -------------------  ----------  --------  -------------------------------------"
@@ -742,6 +750,13 @@ get_fs_type() {
         # Convert zfs_member to just zfs
         if [ "$fs_type" = "zfs_member" ]; then
             echo "zfs"
+        elif [ "$fs_type" = "crypto_LUKS" ]; then
+            local luks_fs="$(get_fs_type "/dev/mapper/$(basename "$device")")"
+            if [ -z "$luks_fs" ]; then
+                echo "luks"
+            else
+                echo "luks+$luks_fs"
+            fi
         else
             echo "${fs_type:-unknown}"
         fi
@@ -753,6 +768,7 @@ get_fs_type() {
 }
 
 # Get mountpoint for a device
+# supports both relative and absolute device names
 get_mountpoint() {
     local device="$1"
     local fs_type="$2"
@@ -767,9 +783,18 @@ get_mountpoint() {
 
     # Handle different filesystem types
     case "$fs_type" in
+        luks\+*)
+            # For LUKS, we need to check the underlying filesystem
+            local luks_fs=$(echo "$fs_type" | cut -d'+' -f2)
+            if [ -n "$luks_fs" ]; then
+                mountpoint=$(get_mountpoint "/dev/mapper/$device" "$luks_fs")
+            fi
+            ;;
         "xfs"|"ext4"|"ext3"|"ext2"|"btrfs")
             # These filesystems can be found directly in /proc/mounts
-            local found_mountpoint=$(grep -w "/dev/$device" /proc/mounts | awk '{print $2}' | head -1)
+            local abs_device=$device
+            [[ "$device" != /dev/* ]] && abs_device="/dev/$device"
+            local found_mountpoint=$(grep -w "$abs_device" /proc/mounts | awk '{print $2}' | head -1)
             if [ -n "$found_mountpoint" ]; then
                 mountpoint="$found_mountpoint"
             fi
@@ -779,8 +804,9 @@ get_mountpoint() {
             # For ZFS, we need to identify the pool name and dataset
             # Get ZFS pool name that contains this device
             if command -v zpool >/dev/null 2>&1; then
+                local rel_device=$(basename "$device")
                 local pool=$(zpool list -H -o name,health | awk '{print $1}' | while read -r pool; do
-                    if zpool status "$pool" 2>/dev/null | grep -q "$device"; then
+                    if zpool status "$pool" 2>/dev/null | grep -q "$rel_device"; then
                         echo "$pool"
                         break
                     fi
@@ -801,7 +827,9 @@ get_mountpoint() {
 
         *)
             # Generic approach for other filesystem types
-            local found_mountpoint=$(grep -w "/dev/$device" /proc/mounts 2>/dev/null | awk '{print $2}' | head -1)
+            local abs_device="$device"
+            [[ "$device" != /dev/* ]] && abs_device="/dev/$device"
+            local found_mountpoint=$(grep -w "$abs_device" /proc/mounts 2>/dev/null | awk '{print $2}' | head -1)
             if [ -n "$found_mountpoint" ]; then
                 mountpoint="$found_mountpoint"
             fi
@@ -2122,6 +2150,30 @@ mount_array_disks() {
             continue
         fi
 
+        if [ "$fs_type" = "luks" ]; then
+            if [ -z "$LUKS_KEYFILE" ] || [ ! -f "$LUKS_KEYFILE" ]; then
+                echo -e "${RED}Error: LUKS device detected but keyfile does not exist. Cannot open LUKS device.${NC}"
+                error_count=$((error_count + 1))
+                continue
+            fi
+            # Open LUKS device
+            echo -n "Slot $slot (${diskname}): Opening LUKS device... "
+            if cryptsetup luksOpen --key-file "$LUKS_KEYFILE" "$device" "$diskname" >/dev/null 2>&1; then
+                echo -e "${GREEN}SUCCESS${NC}"
+                # redetect layered filesystem type after opening LUKS
+                fs_type="$(get_fs_type "$device")"
+            else
+                echo -e "${RED}FAILED${NC}"
+                error_count=$((error_count + 1))
+                continue
+            fi
+        fi
+        # Opened luks device, mount the filesystem
+        if [[ "$fs_type" =~ ^luks\+.* ]]; then
+            fs_type=$(echo "$fs_type" | cut -d'+' -f2)
+            device="/dev/mapper/$diskname"
+        fi
+
         # Handle mounting based on filesystem type
         case "$fs_type" in
             "zfs")
@@ -2228,57 +2280,75 @@ unmount_array_disks() {
             echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}No filesystem detected${NC}"
             skipped_count=$((skipped_count + 1))
             continue
-        elif [ "$current_mountpoint" = "unmounted" ]; then
+        elif [ "$current_mountpoint" = "unmounted" ] && [[ ! "$fs_type" =~ ^luks\+.* ]]; then
             echo -e "Slot $slot (${BLUE}${diskname}${NC}): Already unmounted"
             skipped_count=$((skipped_count + 1))
             continue
         fi
 
-        # Handle unmounting based on filesystem type
-        case "$fs_type" in
-            "zfs")
-                # For ZFS, we need to export the pool
-                # Get the pool name that contains this device
-                local pool_name=""
-                if command -v zpool >/dev/null 2>&1; then
-                    pool_name=$(zpool list -H -o name,health | awk '{print $1}' | while read -r pool; do
-                        if zpool status "$pool" 2>/dev/null | grep -q "$diskname"; then
-                            echo "$pool"
-                            break
-                        fi
-                    done)
-                fi
+        local luks_fs=0
+        if [[ "$fs_type" =~ ^luks\+.* ]]; then
+            fs_type=$(echo "$fs_type" | cut -d'+' -f2)
+            luks_fs=1
+        fi
 
-                if [ -n "$pool_name" ]; then
-                    echo -n "Slot $slot (${diskname}): Exporting ZFS pool $pool_name... "
-                    if zpool export "$pool_name" 2>/dev/null; then
+        if [ "$current_mountpoint" != "unmounted" ]; then
+            # Handle unmounting based on filesystem type
+            case "$fs_type" in
+                "zfs")
+                    # For ZFS, we need to export the pool
+                    # Get the pool name that contains this device
+                    local pool_name=""
+                    if command -v zpool >/dev/null 2>&1; then
+                        pool_name=$(zpool list -H -o name,health | awk '{print $1}' | while read -r pool; do
+                            if zpool status "$pool" 2>/dev/null | grep -q "$diskname"; then
+                                echo "$pool"
+                                break
+                            fi
+                        done)
+                    fi
+
+                    if [ -n "$pool_name" ]; then
+                        echo -n "Slot $slot (${diskname}): Exporting ZFS pool $pool_name... "
+                        if zpool export "$pool_name" 2>/dev/null; then
+                            echo -e "${GREEN}SUCCESS${NC}"
+                            unmounted_count=$((unmounted_count + 1))
+                        else
+                            echo -e "${RED}FAILED${NC}"
+                            error_count=$((error_count + 1))
+                        fi
+                    else
+                        echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}ZFS pool not found${NC}"
+                        skipped_count=$((skipped_count + 1))
+                    fi
+                    ;;
+
+                "xfs"|"ext4"|"ext3"|"ext2"|"btrfs"|*)
+                    echo -n "Slot $slot (${diskname}): Unmounting $fs_type from $current_mountpoint... "
+
+                    # Try unmounting with increasing force if needed
+                    if umount "$current_mountpoint" 2>/dev/null ||
+                    umount -f "$current_mountpoint" 2>/dev/null; then
                         echo -e "${GREEN}SUCCESS${NC}"
                         unmounted_count=$((unmounted_count + 1))
                     else
-                        echo -e "${RED}FAILED${NC}"
+                        echo -e "${RED}FAILED${NC} (Device may be busy)"
                         error_count=$((error_count + 1))
                     fi
-                else
-                    echo -e "Slot $slot (${YELLOW}${diskname}${NC}): ${YELLOW}ZFS pool not found${NC}"
-                    skipped_count=$((skipped_count + 1))
-                fi
-                ;;
+                    ;;
+            esac
+        fi
 
-            "xfs"|"ext4"|"ext3"|"ext2"|"btrfs"|*)
-                echo -n "Slot $slot (${diskname}): Unmounting from $current_mountpoint... "
-
-                # Try unmounting with increasing force if needed
-                if umount "$current_mountpoint" 2>/dev/null ||
-                   umount -f "$current_mountpoint" 2>/dev/null; then
-                    echo -e "${GREEN}SUCCESS${NC}"
-                    unmounted_count=$((unmounted_count + 1))
-                else
-                    echo -e "${RED}FAILED${NC} (Device may be busy)"
-                    echo -e "  You can check what's using it with: ${YELLOW}lsof $current_mountpoint${NC}"
-                    error_count=$((error_count + 1))
-                fi
-                ;;
-        esac
+        # If it was a luks filesystem, close it
+        if [ $luks_fs -eq 1 ]; then
+            echo -n "Slot $slot (${diskname}): Closing LUKS device... "
+            if cryptsetup luksClose "$diskname" 2>/dev/null; then
+                echo -e "${GREEN}SUCCESS${NC}"
+            else
+                echo -e "${RED}FAILED${NC}"
+                error_count=$((error_count + 1))
+            fi
+        fi
     done
 
     echo ""
@@ -2287,7 +2357,6 @@ unmount_array_disks() {
     echo -e "  ${BLUE}$skipped_count${NC} disks skipped (already unmounted or no filesystem)"
     if [ $error_count -gt 0 ]; then
         echo -e "  ${RED}$error_count${NC} disks failed to unmount"
-        echo -e "${YELLOW}Note: Use 'fuser -m <mountpoint>' to see which processes are using the disk${NC}"
         return 1
     fi
 
@@ -2311,6 +2380,22 @@ main() {
                 fi
                 SUPERBLOCK_PATH="$2"
                 shift 2
+                ;;
+            "-k"|"--keyfile")
+                if [ -z "$2" ] || [[ "$2" == -* ]]; then
+                    echo -e "${RED}Error: --keyfile requires a path argument${NC}"
+                    usage
+                fi
+                LUKS_KEYFILE="$2"
+                shift 2
+                ;;
+            "-v"|"--verbose")
+                VERBOSE=1
+                shift
+                ;;
+            "-u|--unattended")
+                UNATTENDED=1
+                shift
                 ;;
             "--no-color")
                 RED=""

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -603,22 +603,31 @@ display_disk_entry() {
     printf "%$((21 - visible_length))s" " " # Use visible length for padding
 
     if [ "$mdstate" = "STARTED" ]; then
-        # Get filesystem type for data disks when array is started
-        if [ -n "$rdevname" ] && [ "$rdevname" != "none" ]; then
+        local mountpoint=""
+
+        # Get filesystem type and mountpoint for data disks when array is started
+        if [ -n "$diskname" ] && [ "$diskname" != "none" ]; then
             # For data disks, get the filesystem type
             if [[ "$idx" != "0" && "$idx" != "29" ]]; then
                 # Check if device exists before calling blkid
-                if [ -b "/dev/$rdevname" ]; then
-                    fs_type=$(get_fs_type "/dev/$rdevname")
+                if [ -b "/dev/$diskname" ]; then
+                    fs_type=$(get_fs_type "/dev/$diskname")
+                    # Get mountpoint if we have a filesystem
+                    if [ -n "$fs_type" ] && [ "$fs_type" != "unknown" ]; then
+                        mountpoint=$(get_mountpoint "$diskname" "$fs_type")
+                    else
+                        mountpoint="unmounted"
+                    fi
                 fi
             else
                 # For parity disks, use slot type (P or Q)
                 fs_type="${slottype:-}"
+                mountpoint="-"
             fi
         fi
 
-        # Include disk name and filesystem columns when array is started
-        printf "%-10s  %-8s  %-14s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-}" "$diskid"
+        # Include disk name, filesystem, and mountpoint columns when array is started
+        printf "%-10s  %-8s  %-14s  %-8s  %-16s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-}" "${mountpoint:-unmounted}" "$diskid"
     else
         # Original format without disk name and filesystem
         printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
@@ -634,8 +643,8 @@ show_disk_status() {
     echo ""
 
     if [ "$mdstate" = "STARTED" ]; then
-        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Drive ID"
-        echo -e "----  -------------------  ----------  --------  -------------   --------  -------------------------------------"
+        echo -e "Slot  Status               Device      Size(GB)  Disk Name       FS        Mountpoint        Drive ID"
+        echo -e "----  -------------------  ----------  --------  -------------   --------  ---------------   -------------------------------------"
     else
         echo -e "Slot  Status               Device      Size(GB)  Drive ID"
         echo -e "----  -------------------  ----------  --------  -------------------------------------"
@@ -730,6 +739,66 @@ get_fs_type() {
 
     echo ""
     return 1
+}
+
+# Get mountpoint for a device
+get_mountpoint() {
+    local device="$1"
+    local fs_type="$2"
+
+    # Default to unmounted
+    local mountpoint="unmounted"
+
+    if [ -z "$device" ] || [ "$device" = "none" ]; then
+        echo "$mountpoint"
+        return 0
+    fi
+
+    # Handle different filesystem types
+    case "$fs_type" in
+        "xfs"|"ext4"|"ext3"|"ext2"|"btrfs")
+            # These filesystems can be found directly in /proc/mounts
+            local found_mountpoint=$(grep -w "/dev/$device" /proc/mounts | awk '{print $2}' | head -1)
+            if [ -n "$found_mountpoint" ]; then
+                mountpoint="$found_mountpoint"
+            fi
+            ;;
+
+        "zfs")
+            # For ZFS, we need to identify the pool name and dataset
+            # Get ZFS pool name that contains this device
+            if command -v zpool >/dev/null 2>&1; then
+                local pool=$(zpool list -H -o name,health | awk '{print $1}' | while read pool; do
+                    if zpool status "$pool" 2>/dev/null | grep -q "$device"; then
+                        echo "$pool"
+                        break
+                    fi
+                done)
+
+                if [ -n "$pool" ]; then
+                    # Check if the pool is mounted
+                    local zfs_mounts=$(zfs list -H -o name,mountpoint | grep -v "none$")
+                    # Start with the pool itself
+                    local found_mountpoint=$(echo "$zfs_mounts" | grep "^$pool[[:blank:]]" | awk '{print $2}' | head -1)
+
+                    if [ -n "$found_mountpoint" ] && [ "$found_mountpoint" != "none" ]; then
+                        mountpoint="$found_mountpoint"
+                    fi
+                fi
+            fi
+            ;;
+
+        *)
+            # Generic approach for other filesystem types
+            local found_mountpoint=$(grep -w "/dev/$device" /proc/mounts 2>/dev/null | awk '{print $2}' | head -1)
+            if [ -n "$found_mountpoint" ]; then
+                mountpoint="$found_mountpoint"
+            fi
+            ;;
+    esac
+
+    echo "$mountpoint"
+    return 0
 }
 
 # Get disk size in 1K blocks


### PR DESCRIPTION
Can mount at least XFS, ZFS and BTRFS filesystems, optionally inside LUKS devices (uses same key-file for opening all LUKS devices).

Mountpoint path is configurable, but ZFS pools are always imported to their default mountpoint.

Refactored show_status, and some other cleanups, and initial verbose and unattended modes.