### PR TITLE
nonraid-tools: add unattended start support, systemd unit file

### DIFF
--- a/.github/workflows/tools-debian.yml
+++ b/.github/workflows/tools-debian.yml
@@ -28,10 +28,15 @@ jobs:
           NEXT_VERSION=$((NEXT_VERSION + 1))
           echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Install Debian Package Building Dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y debhelper build-essential
+
       - name: Create Debian Package
         run: |
           cd tools
-          sudo apt-get update -qq && sudo apt-get install -y debhelper build-essential
+          cp systemd/nonraid.service debian/nonraid-tools.nonraid.service
           dpkg-buildpackage -b -rfakeroot -us -uc
 
       - name: Create Release

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -3,3 +3,6 @@ export DH_VERBOSE=1
 
 %:
 	dh $@ --parallel
+
+override_dh_installsystemd:
+	dh_installsystemd --name=nonraid --no-stop-on-upgrade --no-start

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -47,7 +47,7 @@ usage() {
     echo "  add                         Add a new disk to the array interactively"
     echo "  unassign SLOT               Unassign a disk from the specified slot"
     echo "  reload                      Reload nonraid module with specified superblock"
-    echo "  check                       Start parity check"
+    echo "  check [OPTION]              Start parity check (CORRECT (default), NOCORRECT or RESUME)"
     echo "  nocheck [CANCEL|PAUSE]      Stop parity check (CANCEL or PAUSE)"
     echo "  mount [MOUNTPREFIX]         Mount all active data disks (default prefix: /mnt/disk)"
     echo "  unmount                     Unmount all active data disks"
@@ -55,7 +55,7 @@ usage() {
     echo "Global Options:"
     echo "  -s, --super PATH            Superblock file path to use when loading the module (default: $DEFAULT_SUPERBLOCK)"
     echo "  -k, --keyfile PATH          Path to LUKS keyfile to use during mounting (default: $LUKS_KEYFILE)"
-    echo "  -u, --unattended            Enable unattended mode"
+    echo "  -u, --unattended            Enable unattended mode, will import and start a healthy array without prompts"
     echo "  -v, --verbose               Enable verbose output"
     echo "  -h, --help                  Display this help message"
     echo ""
@@ -684,7 +684,7 @@ display_disk_entry() {
         # Include disk name, filesystem, mountpoint and usage columns when array is started
         if [ "$VERBOSE" -eq 1 ]; then
             # Show drive ID when verbose mode is enabled
-            printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
+            printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s  %s\n" "${rdevname:-none}" "$disksize" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage" "$diskid"
         else
             # Omit drive ID in normal mode
             printf "%-10s  %-8s  %-10s  %-12s  %-16s  %-8s\n" "${rdevname:-none}" "$sizegb" "${diskname:-${slottype:-$idx}}" "${fs_type:-$slottype}" "${mountpoint:-unmounted}" "$usage"
@@ -693,7 +693,7 @@ display_disk_entry() {
         # Original format without disk name and filesystem
         if [ "$VERBOSE" -eq 1 ]; then
             # Show drive ID when verbose mode is enabled
-            printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$sizegb" "$diskid"
+            printf "%-10s  %-8s  %s\n" "${rdevname:-none}" "$disksize" "$diskid"
         else
             # Omit drive ID in normal mode
             printf "%-10s  %-8s\n" "${rdevname:-none}" "$sizegb"
@@ -711,7 +711,7 @@ show_disk_status() {
 
     if [ "$mdstate" = "STARTED" ]; then
         if [ "$VERBOSE" -eq 1 ]; then
-            echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage     Drive ID"
+            echo -e "Slot  Status               Device      Size(1k)  Disk Name   FS            Mountpoint        Usage     Drive ID"
             echo -e "----  -------------------  ----------  --------  ----------  ------------  ---------------   --------  -------------------------------------"
         else
             echo -e "Slot  Status               Device      Size(GB)  Disk Name   FS            Mountpoint        Usage"
@@ -719,7 +719,7 @@ show_disk_status() {
         fi
     else
         if [ "$VERBOSE" -eq 1 ]; then
-            echo -e "Slot  Status               Device      Size(GB)  Drive ID"
+            echo -e "Slot  Status               Device      Size(1k)  Drive ID"
             echo -e "----  -------------------  ----------  --------  -------------------------------------"
         else
             echo -e "Slot  Status               Device      Size(GB)"
@@ -1238,6 +1238,11 @@ start_array() {
                 echo -e "${RED}Array is in ERROR state. Starting may fail or cause data loss.${NC}"
                 ;;
         esac
+
+        if [ "$UNATTENDED" -eq 1 ]; then
+            echo -e "${RED}Error: Cannot start array in abnormal state in unattended mode${NC}"
+            return 1
+        fi
 
         # Ask for confirmation
         read -r -p "Do you want to continue starting the array in this state? (y/N): " confirm
@@ -2216,7 +2221,7 @@ mount_array_disks() {
 
         if [ "$fs_type" = "luks" ]; then
             if [ -z "$LUKS_KEYFILE" ] || [ ! -f "$LUKS_KEYFILE" ]; then
-                echo -e "${RED}Error: LUKS device detected but keyfile does not exist. Cannot open LUKS device.${NC}"
+                echo -e "${RED}Error: LUKS device detected in slot $slot (${diskname}) but keyfile '${LUKS_KEYFILE}' does not exist. Cannot open LUKS device.${NC}"
                 error_count=$((error_count + 1))
                 continue
             fi
@@ -2263,7 +2268,7 @@ mount_array_disks() {
                     mkdir -p "$mountpoint"
                 fi
 
-                echo -n "Slot $slot (${diskname}): Mounting $fs_type to $mountpoint... "
+                echo -n "Slot $slot (${diskname}): Mounting ${fs_type^^} to $mountpoint... "
 
                 if mount "$device" "$mountpoint" 2>/dev/null; then
                     echo -e "${GREEN}SUCCESS${NC}"
@@ -2302,7 +2307,7 @@ unmount_array_disks() {
 
     local mdstate="${NMDSTAT_VALUES[mdState]}"
     if [ "$mdstate" != "STARTED" ]; then
-        echo -e "${RED}Error: Array must be started to unmount disks properly${NC}"
+        echo -e "${RED}Error: Array must be started to unmount disks${NC}"
         echo -e "Current array state: $mdstate"
         return 1
     fi
@@ -2388,7 +2393,7 @@ unmount_array_disks() {
                     ;;
 
                 "xfs"|"ext4"|"ext3"|"ext2"|"btrfs"|*)
-                    echo -n "Slot $slot (${diskname}): Unmounting $fs_type from $current_mountpoint... "
+                    echo -n "Slot $slot (${diskname}): Unmounting ${fs_type^^} from $current_mountpoint... "
 
                     # Try unmounting with increasing force if needed
                     if umount "$current_mountpoint" 2>/dev/null ||
@@ -2457,7 +2462,7 @@ main() {
                 VERBOSE=1
                 shift
                 ;;
-            "-u|--unattended")
+            "-u"|"--unattended")
                 UNATTENDED=1
                 shift
                 ;;
@@ -2522,7 +2527,7 @@ main() {
         "mount")
             mount_array_disks "$1"
             ;;
-        "unmount")
+        "unmount"|"umount")
             unmount_array_disks
             ;;
         *)

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -2250,7 +2250,7 @@ mount_array_disks() {
                 local pool_name="disk${slot}"
                 echo -n "Slot $slot (${diskname}): Importing ZFS pool $pool_name... "
 
-                if zpool import -d "$device" "$pool_name" 2>/dev/null; then
+                if zpool import -o cachefile=none -d "$device" "$pool_name" 2>/dev/null; then
                     echo -e "${GREEN}SUCCESS${NC}"
                     mounted_count=$((mounted_count + 1))
                 else

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1209,6 +1209,16 @@ start_array() {
         return 1
     fi
 
+    # If no disks were imported, warn the user, and refuse to start in unattended mode
+    if [ "$imported_disks" -eq 0 ]; then
+        if [ "$UNATTENDED" -eq 1 ]; then
+            echo -e "${RED}Error: No disks imported. Cannot start array (unattended mode)${NC}"
+            return 1
+        else
+            echo -e "${YELLOW}Warning: No disks imported.${NC}"
+        fi
+    fi
+
     # Check array state and proceed based on it
     if [ "$mdstate" = "STOPPED" ]; then
         # Normal state, proceed without confirmation

--- a/tools/systemd/nonraid.service
+++ b/tools/systemd/nonraid.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Start/Stop NonRAID array and manage mounts
+Requires=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment="SUPER=/nonraid.dat"
+EnvironmentFile=-/etc/default/nonraid
+ExecStart=nmdctl -u -v -s $SUPER start
+ExecStart=nmdctl -u mount
+ExecStop=nmdctl -u unmount
+ExecStop=nmdctl -u stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd unit file will use `nmdctl` in unattended mode, which will start the array and mount data disks, if it can be done safely, without prompting the user.