### PR TITLE
nmdctl: "new config" mode and misc fixes and cleanups

### DIFF
--- a/.github/workflows/tools-debian.yml
+++ b/.github/workflows/tools-debian.yml
@@ -3,6 +3,11 @@ name: Build nonraid-tools Debian Package
 on:
   workflow_dispatch:
     inputs:
+      create_release:
+        description: 'Create GitHub release'
+        required: false
+        default: false
+        type: boolean
       prerelease:
         description: 'Create as prerelease'
         required: false
@@ -20,13 +25,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get Next Version Number
-        id: get-version
+      - name: Get nmdctl version
+        id: get-nmdctl
         run: |
-          # Get count of existing nonraid-tools tags and increment by 1
-          NEXT_VERSION=$(git tag -l "nonraid-tools-*" | wc -l)
-          NEXT_VERSION=$((NEXT_VERSION + 1))
-          echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          # Get the version from the nmdctl binary
+          VERSION=$(grep VERSION= tools/nmdctl | cut -d= -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get Next Build Number
+        id: get-build
+        run: |
+          NEXT_BUILD=$(git tag -l "nonraid-tools-${{ steps.get-nmdctl.outputs.version }}-*" | wc -l)
+          NEXT_BUILD=$((NEXT_BUILD + 1))
+          echo "build=$NEXT_BUILD" >> $GITHUB_OUTPUT
 
       - name: Install Debian Package Building Dependencies
         run: |
@@ -36,24 +47,34 @@ jobs:
       - name: Create Debian Package
         run: |
           cd tools
+          sed -i "s/1.0.0-1/${{ steps.get-nmdctl.outputs.version }}-${{ steps.get-build.outputs.build }}/" debian/changelog
           cp systemd/nonraid.service debian/nonraid-tools.nonraid.service
           dpkg-buildpackage -b -rfakeroot -us -uc
 
+      - name: Upload Debian Package as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nonraid-tools-${{ steps.get-nmdctl.outputs.version }}-${{ steps.get-build.outputs.build }}
+          path: "*.deb"
+          retention-days: 30
+
       - name: Create Release
+        if: ${{ github.event.inputs.create_release == 'true' }}
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prerelease: ${{ github.event.inputs.prerelease }}
-          tag_name: nonraid-tools-${{ steps.get-version.outputs.version }}
-          name: NonRAID Tools Debian Package - Build ${{ steps.get-version.outputs.version }}
+          tag_name: nonraid-tools-${{ steps.get-nmdctl.outputs.version }}-${{ steps.get-build.outputs.build }}
+          name: NonRAID Tools Debian Package - Version ${{ steps.get-nmdctl.outputs.version }} Build ${{ steps.get-build.outputs.build }}
           body: |
-            **NonRAID Tools Package - Build ${{ steps.get-version.outputs.version }}**
+            **NonRAID Tools Package - Version ${{ steps.get-nmdctl.outputs.version }} Build ${{ steps.get-build.outputs.build }}**
 
             This release contains the NonRAID array management tools package for Ubuntu/Debian systems.
 
             ## What's Included
             - `/usr/bin/nmdctl`
+            - `nonraid.service` systemd unit file
 
             ## Installation
             ```bash

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -950,7 +950,7 @@ get_disk_size_kb() {
         return 1
     fi
 
-    # Use blockdev to get exact size in 512-byte sectors
+    # Use blockdev to get exact size in 512-byte logical sectors
     local sectors=$(blockdev --getsz "$device" 2>/dev/null)
     if [ -n "$sectors" ]; then
         # Round down to nearest multiple of 8 sectors (driver reads/writes 8 sectors at a time)
@@ -1404,6 +1404,8 @@ create_array() {
     # Get current superblock path
     local superblock="${SUPERBLOCK_PATH:-$DEFAULT_SUPERBLOCK}"
     local is_new_superblock=0
+    local do_new_config=0
+    local do_parity_skip=0
 
     # Check if this will be a new superblock
     if [ ! -f "$superblock" ]; then
@@ -1422,13 +1424,38 @@ create_array() {
         return 1
     fi
 
+    # Check if the array is already started
+    local mdstate=$(get_nmdstat_value "mdState")
+    if [ "$mdstate" != "STOPPED" ]; then
+        echo -e "${RED}Error: The array is not currently stopped. Please stop it first.${NC}"
+        return 1
+    fi
+
     # Verify no disks are defined in the array
     local disk_count=$(get_defined_slots_count)
     if [ "$disk_count" -gt 0 ] && [ "$is_new_superblock" -eq 0 ]; then
-        echo -e "${RED}Error: The array already has $disk_count disk(s) defined${NC}"
-        echo -e "${YELLOW}To create a new array, unload and reload the module with a new or empty superblock${NC}"
-        echo -e "Use: ${GREEN}nmdctl --super /path/to/new/superblock.dat reload${NC}"
-        return 1
+        echo -e "${YELLOW}Warning: The array already has $disk_count disk(s) configured${NC}"
+        echo ""
+        read -r -p "Do you want to recreate the current array with a new config? [y/N]: " response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            get_all_nmdstat_values NMDSTAT_VALUES
+            do_new_config=1
+            echo -e "Saving old superblock as ${GREEN}${superblock}.bak${NC}"
+            if ! mv "$superblock" "${superblock}.bak" 2>/dev/null; then
+                echo -e "${RED}Error: Failed to move old superblock${NC}"
+                return 1
+            fi
+            echo -e "${YELLOW}Reloading module with empty superblock...${NC}"
+            if ! reload_module 1; then
+                echo -e "${RED}Error: Failed to reload module with empty superblock - restoring old superblock and aborting${NC}"
+                mv "${superblock}.bak" "$superblock" 2>/dev/null
+                return 1
+            fi
+            echo -e "${GREEN}Module reloaded successfully${NC}"
+        else
+            echo "Operation cancelled."
+            return 1
+        fi
     fi
 
     echo -e "=== ${BLUE}Creating New NonRAID Array${NC} ==="
@@ -1482,6 +1509,35 @@ create_array() {
             echo -e "ID: Unknown"
         fi
         echo ""
+        if [ "$do_new_config" -eq 1 ]; then
+            # Check if this disk was previously assigned to the array
+            local prev_slot=""
+            local prev_slot_type=""
+            if [ -n "$disk_id" ]; then
+                # Search through all previously configured slots to find where this disk was assigned
+                for check_slot in $(get_defined_slots); do
+                    local check_disk_id="${NMDSTAT_VALUES[diskId.$check_slot]}"
+                    if [ -n "$check_disk_id" ] && [[ "$disk_id" == *"$check_disk_id"* ]] || [[ "$check_disk_id" == *"$disk_id"* ]]; then
+                        prev_slot="$check_slot"
+                        if [ "$check_slot" = "0" ]; then
+                            prev_slot_type="P (Parity)"
+                        elif [ "$check_slot" = "29" ]; then
+                            prev_slot_type="Q (Second Parity)"
+                        else
+                            prev_slot_type="Data"
+                        fi
+                        break
+                    fi
+                done
+
+                if [ -n "$prev_slot" ]; then
+                    echo -e "${GREEN}Previously assigned:${NC} Slot $prev_slot ($prev_slot_type)"
+                    echo ""
+                else
+                    echo -e "${YELLOW}No previous slot assignment found for this disk${NC}"
+                fi
+            fi
+        fi
 
         # Show which slots are already assigned
         if [ ${#assigned_slots[@]} -gt 0 ]; then
@@ -1495,6 +1551,9 @@ create_array() {
             echo -e " P or 0: Parity disk"
             echo -e " Q or 29: Second parity disk (optional)"
             echo -e " 1-28: Data disk"
+            if [ "$do_new_config" -eq 1 ] && [ -n "$prev_slot" ]; then
+                echo -e " o: Use old slot ($prev_slot - $prev_slot_type)"
+            fi
             echo -e " s: Skip this disk"
             echo -e " f: Finish array creation"
             read -r -p "Choice: " choice
@@ -1513,6 +1572,15 @@ create_array() {
                         slot="$choice"
                     else
                         echo -e "${RED}Invalid slot number. Please use 0-29.${NC}"
+                        continue
+                    fi
+                    ;;
+                [Oo])
+                    if [ "$do_new_config" -eq 1 ] && [ -n "$prev_slot" ]; then
+                        slot="$prev_slot"
+                        echo -e "${GREEN}Using previous slot assignment: $slot${NC}"
+                    else
+                        echo -e "${RED}No previous slot assigned for this disk.${NC}"
                         continue
                     fi
                     ;;
@@ -1572,6 +1640,33 @@ create_array() {
         run_nmd_command "label $array_label"
     fi
 
+    # Offer "parity is valid" option
+    if [ "$do_new_config" -eq 1 ]; then
+        echo ""
+        echo "If you have done the new configuration in a very particular way, you can mark the parity valid for the new array."
+        echo "This avoids parity reconstruction when starting the array."
+        echo ""
+        echo -e "Only do this if you are SURE the ${YELLOW}parity is already valid.${NC}"
+        read -r -p "Is the array parity already valid? (y/N): " parity_valid
+        if [[ "$parity_valid" =~ ^[Yy]$ ]]; then
+            echo -e "${YELLOW}Marking parity valid for the next array start.${NC}"
+            do_parity_skip=1
+            local invalidslot="98"
+            # mark Q valid only if it is still in the array
+            if [[ " ${assigned_slots[*]} " =~ " 29 " ]]; then
+                invalidslot="$invalidslot 99"
+            else
+                invalidslot="$invalidslot 29"
+            fi
+            if ! run_nmd_command "set invalidslot $invalidslot"; then
+                echo -e "${RED}Error: Failed to mark parity valid${NC}"
+                return 1
+            fi
+        else
+            echo -e "${YELLOW}Parity will require reconstruction when the array is started.${NC}"
+        fi
+    fi
+
     # Show array status
     echo ""
     show_status
@@ -1588,7 +1683,11 @@ create_array() {
     # XXX: FIXME: need to reload the module to reset internal state
     echo ""
     echo -e "${YELLOW}Note: You may need to reload the module to reset the internal state"
-    echo -e "if after parity reconstruction the array state is still DEGRADED.${NC}"
+    if [ "$do_parity_skip" -eq 1 ]; then
+        echo -e "if after array start the array state is still DEGRADED.${NC}"
+    else
+        echo -e "if after parity reconstruction the array state is still DEGRADED.${NC}"
+    fi
     echo -e "${YELLOW}Use: ${GREEN}nmdctl reload${NC}"
     return 0
 }
@@ -2073,6 +2172,7 @@ unassign_disk() {
 
 # Reload nonraid module with superblock
 reload_module() {
+    local quiet_mode="${1:-0}"
     check_root
 
     # Get current superblock path
@@ -2093,47 +2193,61 @@ reload_module() {
 
     # Check if superblock file exists, but allow non-existent files for creating new arrays
     if [ ! -f "$superblock" ]; then
-        echo -e "${YELLOW}Warning: Superblock file not found: $superblock${NC}"
-        echo -e "${YELLOW}This will create a new superblock when the array is started.${NC}"
+        if [ "$quiet_mode" -eq 0 ]; then
+            echo -e "${YELLOW}Warning: Superblock file not found: $superblock${NC}"
+            echo -e "${YELLOW}This will create a new superblock when the array is started.${NC}"
 
-        # Ask for confirmation if creating a new superblock
-        read -r -p "Continue with a new superblock? (y/N): " confirm
-        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
-            echo "Operation cancelled."
-            return 1
+            # Ask for confirmation if creating a new superblock
+            read -r -p "Continue with a new superblock? (y/N): " confirm
+            if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+                echo "Operation cancelled."
+                return 1
+            fi
+            echo -e "Proceeding with new superblock at: ${GREEN}$superblock${NC}"
         fi
-        echo -e "Proceeding with new superblock at: ${GREEN}$superblock${NC}"
     fi
 
     # Check if module is loaded
     if ! lsmod | grep -q nonraid; then
-        echo -e "${YELLOW}NonRAID module not loaded. Loading with superblock: $superblock${NC}"
+        if [ "$quiet_mode" -eq 0 ]; then
+            echo -e "${YELLOW}NonRAID module not loaded. Loading with superblock: $superblock${NC}"
+        fi
         if ! modprobe nonraid super="$superblock"; then
             echo -e "${RED}Error: Failed to load nonraid module${NC}"
             return 1
         fi
-        echo -e "${GREEN}Successfully loaded nonraid module${NC}"
+        if [ "$quiet_mode" -eq 0 ]; then
+            echo -e "${GREEN}Successfully loaded nonraid module${NC}"
+        fi
         return 0
     fi
 
-    echo -e "${YELLOW}Stopping array and reloading nonraid module...${NC}"
+    if [ "$quiet_mode" -eq 0 ]; then
+        echo -e "${YELLOW}Stopping array and reloading nonraid module...${NC}"
+    fi
 
     # Stop array if it's running
     local mdstate=""
     if [ -f /proc/nmdstat ]; then
         mdstate=$(get_nmdstat_value "mdState")
         if [ "$mdstate" = "STARTED" ]; then
-            echo "Stopping array first..."
+            if [ "$quiet_mode" -eq 0 ]; then
+                echo "Stopping array first..."
+            fi
             if ! run_nmd_command "stop"; then
                 echo -e "${RED}Error: Failed to stop array. Cannot safely reload module.${NC}"
                 return 1
             fi
-            echo -e "Array stopped successfully."
+            if [ "$quiet_mode" -eq 0 ]; then
+                echo -e "Array stopped successfully."
+            fi
         fi
     fi
 
     # Unload module
-    echo "Unloading nonraid module..."
+    if [ "$quiet_mode" -eq 0 ]; then
+        echo "Unloading nonraid module..."
+    fi
     if ! modprobe -r nonraid; then
         echo -e "${RED}Error: Failed to unload nonraid module. It may be in use.${NC}"
         return 1
@@ -2143,13 +2257,17 @@ reload_module() {
     sleep 1
 
     # Load module with specified superblock
-    echo "Loading nonraid module with superblock: $superblock"
+    if [ "$quiet_mode" -eq 0 ]; then
+        echo "Loading nonraid module with superblock: $superblock"
+    fi
     if ! modprobe nonraid super="$superblock"; then
         echo -e "${RED}Error: Failed to reload nonraid module${NC}"
         return 1
     fi
 
-    echo -e "${GREEN}Successfully reloaded nonraid module with superblock: $superblock${NC}"
+    if [ "$quiet_mode" -eq 0 ]; then
+        echo -e "${GREEN}Successfully reloaded nonraid module with superblock: $superblock${NC}"
+    fi
     return 0
 }
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1285,7 +1285,7 @@ start_array() {
 
         case "$mdstate" in
             "NEW_ARRAY")
-                echo -e "${YELLOW}This is a NEW_ARRAY and will require parity construction.${NC}"
+                echo -e "${YELLOW}This is a new array being started for the first time.${NC}"
                 ;;
             "RECON_DISK")
                 echo -e "${YELLOW}One or more disks need reconstruction.${NC}"

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -108,8 +108,7 @@ check_module_loaded() {
                 echo -e "Attempting to create array with: ${YELLOW}$superblock${NC}"
                 echo -e ""
                 echo -e "This could accidentally modify the wrong superblock file."
-                echo -e "Please unload the module first with: ${YELLOW}modprobe -r nonraid${NC}"
-                echo -e "Or use: ${YELLOW}nmdctl --super $superblock reload${NC}"
+                echo -e "Explicitly reload the module with the new superblock with: ${YELLOW}nmdctl --super $superblock reload${NC}"
                 return 1
             fi
         fi

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -4,12 +4,14 @@
 # nmdctl - NonRAID array management utility
 #
 
-
 # Check for bash version 4 or higher (needed for associative arrays)
 if ((BASH_VERSINFO[0] < 4)); then
     echo "Error: This script requires bash version 4 or higher"
     exit 1
 fi
+
+# Our version
+VERSION=1.1.0
 
 # Colors for pretty output
 RED='\033[0;31m'
@@ -57,6 +59,7 @@ usage() {
     echo "  -k, --keyfile PATH          Path to LUKS keyfile to use during mounting (default: $LUKS_KEYFILE)"
     echo "  -u, --unattended            Enable unattended mode, will import and start a healthy array without prompts"
     echo "  -v, --verbose               Enable verbose output"
+    echo "  -V, --version               Display version information"
     echo "  -h, --help                  Display this help message"
     echo ""
     exit 1
@@ -2650,6 +2653,10 @@ main() {
                 YELLOW=""
                 NC=""
                 shift
+                ;;
+            "-V"|"--version")
+                echo "nmdctl version $VERSION"
+                exit 0
                 ;;
             "-h"|"--help"|"help")
                 usage

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1262,7 +1262,7 @@ start_array() {
     fi
 
     # If no disks were imported, warn the user, and refuse to start in unattended mode
-    if [ "$imported_disks" -eq 0 ]; then
+    if [ "$imported_disks" -eq 0 ] && [ "$mdstate" != "NEW_ARRAY" ]; then
         if [ "$UNATTENDED" -eq 1 ]; then
             echo -e "${RED}Error: No disks imported. Cannot start array (unattended mode)${NC}"
             return 1

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1454,9 +1454,8 @@ create_array() {
     local array_label=""
     read -r -p "Enter a label for the array (optional): " array_label
     if [ -n "$array_label" ]; then
-        # Set array label if provided
-        echo "Setting array label: $array_label"
-        run_nmd_command "label $array_label"
+        # Defer setting the label until disks have been added to array
+        echo "Will set array label to: $array_label"
     fi
     echo ""
 
@@ -1567,6 +1566,11 @@ create_array() {
     fi
 
     echo -e "${GREEN}Successfully assigned $assigned_count disk(s) to the array${NC}"
+
+    # Now set the array label if provided
+    if [ -n "$array_label" ]; then
+        run_nmd_command "label $array_label"
+    fi
 
     # Show array status
     echo ""

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -596,15 +596,19 @@ show_resync_status() {
     local mdresynccorr="${NMDSTAT_VALUES[mdResyncCorr]}"
 
     # Check for pending disk clearing
+    local array_start_maybe="Start the array and use"
+    if [ "${NMDSTAT_VALUES[mdState]}" = "STARTED" ]; then
+        array_start_maybe="Use"
+    fi
     if [ "$mdresync" = "0" ] && [ "$mdresyncaction" = "clear" ]; then
         echo ""
         echo -e "${YELLOW}Disk clearing pending: New disk needs to be cleared${NC}"
-        echo -e "${YELLOW}Start the array and use '${GREEN}nmdctl check${YELLOW}' command to start the disk clear${NC}"
+        echo -e "${YELLOW}${array_start_maybe} '${GREEN}nmdctl check${YELLOW}' command to start the disk clear${NC}"
     # Check for pending reconstruction
     elif [ "$mdresync" = "0" ] && [[ "$mdresyncaction" == recon* ]]; then
         echo ""
         echo -e "${YELLOW}Disk reconstruction pending: ${BLUE}$mdresyncaction${NC}"
-        echo -e "${YELLOW}Start the array and use '${GREEN}nmdctl check${YELLOW}' command to start the reconstruction${NC}"
+        echo -e "${YELLOW}${array_start_maybe} '${GREEN}nmdctl check${YELLOW}' command to start the reconstruction${NC}"
     # Check for active reconstruction or check operation
     elif [ "$mdresync" != "0" ] && [ -n "$mdresync" ]; then
         local mdresyncpos="${NMDSTAT_VALUES[mdResyncPos]}"

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -1358,18 +1358,14 @@ list_available_devices() {
             local partition=""
             if [ -b "${dev}1" ]; then
                 partition="${dev}1"
-            elif [ -b "${dev}p1" ]; then
-                partition="${dev}p1"
             else
                 continue  # Skip if we can't find the partition
             fi
 
-            # Get device details using a more reliable approach
-            # Get disk ID without using xargs and pipeline
+            # Get device details
             local disk_id=""
             if [ -d "/dev/disk/by-id" ]; then
                 local dev_name=$(basename "$dev")
-                # Use a safer approach to find the matching disk ID
                 for id_path in /dev/disk/by-id/*; do
                     if [ -L "$id_path" ] && [[ "$id_path" != *-part* ]]; then
                         local link_target=$(readlink -f "$id_path")

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -242,6 +242,59 @@ format_array_state() {
     esac
 }
 
+# Check if the nonraid driver is in an inconsistent state
+# Returns 0 if inconsistent, 1 if consistent
+check_driver_inconsistent_state() {
+    # If NMDSTAT_VALUES is empty, populate it first
+    if [ ${#NMDSTAT_VALUES[@]} -eq 0 ]; then
+        get_all_nmdstat_values NMDSTAT_VALUES
+    fi
+
+    # Get the mdnum* counter values
+    local mdnummissing="${NMDSTAT_VALUES[mdNumMissing]:-0}"
+    local mdnuminvalid="${NMDSTAT_VALUES[mdNumInvalid]:-0}"
+    local mdnumwrong="${NMDSTAT_VALUES[mdNumWrong]:-0}"
+    local mdnumdisabled="${NMDSTAT_VALUES[mdNumDisabled]:-0}"
+    local mdnumreplaced="${NMDSTAT_VALUES[mdNumReplaced]:-0}"
+    local mdnumnew="${NMDSTAT_VALUES[mdNumNew]:-0}"
+
+    # Check if any counter has a value > 0
+    local has_counter_activity=0
+    if [ "$mdnummissing" -gt 0 ] || [ "$mdnuminvalid" -gt 0 ] ||
+       [ "$mdnumwrong" -gt 0 ] || [ "$mdnumdisabled" -gt 0 ] ||
+       [ "$mdnumreplaced" -gt 0 ] || [ "$mdnumnew" -gt 0 ]; then
+        has_counter_activity=1
+    fi
+
+    # If counters are clean, there's at least no known driver state inconsistency
+    if [ "$has_counter_activity" -eq 0 ]; then
+        return 1
+    fi
+
+    # If array is empty, we should be OK for now
+    if [ "$(get_defined_slots_count)" -eq 0 ]; then
+        return 1
+    fi
+
+    # Check if all defined disks are in DISK_OK state
+    local all_disks_ok=1
+    for slot in $(get_defined_slots); do
+        local rdevstatus="${NMDSTAT_VALUES[rdevStatus.$slot]}"
+        if [ "$rdevstatus" != "DISK_OK" ]; then
+            all_disks_ok=0
+            break
+        fi
+    done
+
+    # Inconsistent state: counters show activity but all disks are OK
+    if [ "$all_disks_ok" -eq 1 ]; then
+        return 0
+    fi
+
+    # No known inconsistencies found
+    return 1
+}
+
 # Get count of defined disk slots in the array
 # Returns the count of all slots with a defined disk
 get_defined_slots_count() {
@@ -447,6 +500,16 @@ show_status() {
 
     # Show array summary (state, label, superblock, disks present)
     show_array_summary
+
+    # Check for driver inconsistent state and show warning
+    if check_driver_inconsistent_state; then
+        echo ""
+        echo -e "${YELLOW}WARNING: Driver internal state is inconsistent!${NC}"
+        echo -e "${YELLOW}The array mdNum* counters show non-zero values, but all individual disks are DISK_OK status.${NC}"
+        echo -e "${YELLOW}This can happen after initial array creation, but it may cause unexpected behavior.${NC}"
+        echo -e "${YELLOW}Recommend reloading the driver and starting the array again: ${GREEN}nmdctl reload && nmdctl start${NC}"
+        echo ""
+    fi
 
     # Show array health status
     determine_array_health

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -951,29 +951,16 @@ get_disk_size_kb() {
     fi
 
     # Use blockdev to get exact size in 512-byte sectors
-    if command -v blockdev >/dev/null 2>&1; then
-        local sectors=$(blockdev --getsz "$device" 2>/dev/null)
-        if [ -n "$sectors" ]; then
-            # Round down to nearest multiple of 8 sectors (driver reads/writes 8 sectors at a time)
-            local adjusted_sectors=$(( (sectors / 8) * 8 ))
-            # Convert to 1K blocks (2 sectors = 1KB)
-            local kb_size=$(( adjusted_sectors / 2 ))
-            echo "$kb_size"
-            return 0
-        fi
-    fi
-
-    # Fallback to fdisk if blockdev not available
-    local sectors=$(fdisk -l "$device" 2>/dev/null | grep "^Disk $device" | awk '{print $7}')
+    local sectors=$(blockdev --getsz "$device" 2>/dev/null)
     if [ -n "$sectors" ]; then
         # Round down to nearest multiple of 8 sectors (driver reads/writes 8 sectors at a time)
         local adjusted_sectors=$(( (sectors / 8) * 8 ))
         # Convert to 1K blocks (2 sectors = 1KB)
         local kb_size=$(( adjusted_sectors / 2 ))
         echo "$kb_size"
-    else
-        return 1
+        return 0
     fi
+    return 1
 }
 
 # Find disk device name matching the ID in nmdstat


### PR DESCRIPTION
"New config" mode allows array recreation, giving option of using old slot assignments, and then marking parity as valid. Can be used to for example shrink array.