### PR TITLE
nmdctl: add_disk: fix suggesting adding already existing parity slot

### DIFF
--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -3469,9 +3469,9 @@ add_disk() {
         # Priority suggestion list: any missing disks, then parity disks
         if [ ${#replaceable_slots[@]} -gt 0 ]; then
             echo -e "${YELLOW}You should replace unassigned disk in slots: ${GREEN}${replaceable_slots[*]}${NC}"
-        elif [ -z "${NMDSTAT_VALUES[rdevId.0]}" ]; then
+        elif [ -z "${NMDSTAT_VALUES[rdevId.0]}" ] && [ -z "${NMDSTAT_VALUES[diskId.0]}" ]; then
             echo -e "${YELLOW}No parity disk found. Consider adding a parity disk (slot 0).${NC}"
-        elif [ -z "${NMDSTAT_VALUES[rdevId.29]}" ]; then
+        elif [ -z "${NMDSTAT_VALUES[rdevId.29]}" ] && [ -z "${NMDSTAT_VALUES[diskId.29]}" ]; then
             echo -e "${YELLOW}No second parity disk found. You may add one (slot 29) for dual parity.${NC}"
         fi
 


### PR DESCRIPTION
When disks are not yet imported to array, we need to check `diskId` instead of `rdevId` to see if slot is populated.

Fixes #72 