### PR TITLE
Remove local-fs requirement for nonraid service

### DIFF
--- a/tools/systemd/nonraid.service
+++ b/tools/systemd/nonraid.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Start/Stop NonRAID array and manage mounts
-Requires=local-fs.target
-After=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Remove local-fs requirement for the nonraid.service, as it is not needed. Furthermore it might create dependencies loop. If the Nonraid mounts are mounted via fstab or systemd mount units, there will be dependencies loop, as the mount unit would need nonraid.service, who would need the local-fs.target.