### PR TITLE
nmdctl: warn if partition locked by another process during import

### DIFF
--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -11,7 +11,7 @@ if ((BASH_VERSINFO[0] < 4)); then
 fi
 
 # Our version
-VERSION=1.22.1
+VERSION=1.23.0
 
 # Colors for pretty output
 RED='\033[0;31m'

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -2154,9 +2154,13 @@ find_partition() {
                 fi
             fi
             if [ "$dev_locked" -eq 0 ]; then
-                # If python is not available or device was not locked, return the partition
+                # If python is not available or device was not locked, return the partition and return 0
                 echo "$partition"
                 return 0
+            else
+                # If device is locked, return the partition but with a special code to indicate it's in use by another process
+                echo "$partition"
+                return 2
             fi
         fi
     fi
@@ -2261,6 +2265,11 @@ import_disks() {
         local partition=""
         if [ -n "$found_device" ]; then
             partition="$(find_partition "$found_device")"
+            local find_rc=$?
+            if [ "$find_rc" -eq 2 ]; then
+                echo -e "${YELLOW}Warning: Partition $partition on $found_device is locked by another process, skipping${NC}"
+                partition=""
+            fi
             if [ -n "$partition" ]; then
                 # Get the partition size
                 local disk_size=$(get_disk_size_kb "$partition")
@@ -2737,7 +2746,12 @@ list_available_devices() {
     # Find all disk devices
     for dev in $(lsblk -n -d -I "$include_majors" -o path 2>/dev/null); do
         # Find partition, largest on the disk and must not be mounted
-        local partition=$(find_partition "$dev")
+        local partition
+        partition=$(find_partition "$dev")
+        local find_rc=$?
+        if [ "$find_rc" -eq 2 ]; then
+            continue
+        fi
         if [ -n "$partition" ]; then
             # Get disk id
             local disk_id=""


### PR DESCRIPTION
Makes `nmdctl` give a separate warning if a partition is already locked by another process when trying to import it:
```
# ./nmdctl import
Scanning array configuration...
Found disk for slot 0: sdd1 (ID: VBOX_HARDDISK_VBb584354a-302d68db)
Warning: Partition /dev/sdb1 on /dev/sdb is locked by another process, skipping
Warning: No partition found for disk /dev/sdb
Found disk for slot 2: sde1 (ID: VBOX_HARDDISK_VB708909cb-8b114b74)
Found disk for slot 3: sdc1 (ID: VBOX_HARDDISK_VB9c8a60bc-22209161)
Found disk for slot 4: sdf1 (ID: VBOX_HARDDISK_VB376a3060-4e62ab7a)
```

The "no partition found" warning was misleading in these cases, as seen in #114.