### PR TITLE
Support explicit disk offsets

### DIFF
--- a/.github/workflows/dkms-integration-tests.yml
+++ b/.github/workflows/dkms-integration-tests.yml
@@ -117,7 +117,6 @@ jobs:
           echo "Created loop devices: $disk1, $disk2, $disk3, $disk4"
 
           # Create partitions
-          sudo sgdisk -o -a 8 -n 1:32K:0 $disk1
           sudo sgdisk -o -a 8 -n 1:32K:0 $disk2
           sudo sgdisk -o -a 8 -n 1:32K:0 $disk3
           sudo sgdisk -o -a 8 -n 1:32K:0 $disk4
@@ -136,11 +135,11 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           echo "Get disk size with nmdctl get_disk_size_kb"
-          size=$(sudo bash -c "source tools/nmdctl; get_disk_size_kb ${DISK1}p1")
+          size=$(sudo bash -c "source tools/nmdctl; get_disk_size_kb ${DISK2}p1")
 
           # Create array using nmdctl with parametric mode
           echo "Creating NonRAID array with nmdctl..."
-          sudo bash tools/nmdctl create --force P:${DISK1}p1:$(basename $DISK1) 1:${DISK2}p1:$(basename $DISK2) 2:${DISK3}p1:$(basename $DISK3)
+          sudo bash tools/nmdctl create --force P:${DISK1}:$(basename $DISK1) 1:${DISK2}p1:$(basename $DISK2) 2:${DISK3}:$(basename $DISK3):64
 
           sleep 2 # Give array creation time to process
 

--- a/tools/nmdctl
+++ b/tools/nmdctl
@@ -31,6 +31,13 @@ SUPERBLOCK_PATH=""
 # LUKS keyfile path
 LUKS_KEYFILE="/etc/nonraid/luks-keyfile"
 
+# Persisted per-disk import offsets (sectors), keyed by disk ID.
+# The kernel driver does not persist a disk's import offset in its on-disk
+# superblock, so nmdctl records any non-zero offset here itself and reuses it
+# when re-importing disks after a module reload (see save_disk_offset/
+# get_saved_disk_offset).
+DISK_OFFSETS_FILE="/etc/nonraid/disk-offsets"
+
 # verbose, unattended
 VERBOSE=0
 UNATTENDED=0
@@ -2117,9 +2124,11 @@ get_fs_usage() {
     return 0
 }
 
-# Get disk size in 1K blocks
+# Get disk size in 1K blocks, optionally subtracting an offset (in 512-byte sectors)
+# Usage: get_disk_size_kb <device> [offset_sectors]
 get_disk_size_kb() {
     local device="$1"
+    local offset_sectors="${2:-0}"
     if [ ! -b "$device" ]; then
         return 1
     fi
@@ -2127,6 +2136,10 @@ get_disk_size_kb() {
     # Use blockdev to get exact size in 512-byte logical sectors
     local sectors=$(blockdev --getsz "$device" 2>/dev/null)
     if [ -n "$sectors" ]; then
+        # Subtract offset if provided
+        if [ "$offset_sectors" -gt 0 ]; then
+            sectors=$(( sectors - offset_sectors ))
+        fi
         # Round down to nearest multiple of 8 sectors (driver reads/writes 8 sectors at a time)
         local adjusted_sectors=$(( (sectors / 8) * 8 ))
         # Convert to 1K blocks (2 sectors = 1KB)
@@ -2135,6 +2148,48 @@ get_disk_size_kb() {
         return 0
     fi
     return 1
+}
+
+# Save the import offset (in 512-byte sectors) used for a disk ID, so it can be
+# recovered on a later reload/import. Always clears any previously recorded
+# offset for this disk ID first (e.g. if a disk is later re-added/replaced
+# without an offset, the stale record must not linger), then only writes a
+# new entry if offset is > 0.
+# Usage: save_disk_offset <disk_id> <offset_sectors>
+save_disk_offset() {
+    local disk_id="$1"
+    local offset="${2:-0}"
+
+    [ -z "$disk_id" ] && return 0
+
+    # Remove any existing entry for this disk ID (exact match on first field)
+    if [ -f "$DISK_OFFSETS_FILE" ]; then
+        awk -v id="$disk_id" '$1 != id' "$DISK_OFFSETS_FILE" > "${DISK_OFFSETS_FILE}.tmp" 2>/dev/null
+        mv "${DISK_OFFSETS_FILE}.tmp" "$DISK_OFFSETS_FILE"
+    fi
+
+    [ "$offset" -le 0 ] 2>/dev/null && return 0
+
+    local dir
+    dir=$(dirname "$DISK_OFFSETS_FILE")
+    mkdir -p "$dir" 2>/dev/null
+    echo "$disk_id $offset" >> "$DISK_OFFSETS_FILE"
+    return 0
+}
+
+# Get the previously saved import offset (in 512-byte sectors) for a disk ID.
+# Echoes 0 if none is recorded.
+# Usage: get_saved_disk_offset <disk_id>
+get_saved_disk_offset() {
+    local disk_id="$1"
+    local offset=0
+
+    if [ -n "$disk_id" ] && [ -f "$DISK_OFFSETS_FILE" ]; then
+        offset=$(awk -v id="$disk_id" '$1 == id { val = $2 } END { print val }' "$DISK_OFFSETS_FILE" 2>/dev/null)
+        [ -z "$offset" ] && offset=0
+    fi
+    echo "$offset"
+    return 0
 }
 
 # Find an unused largest partition for a given disk device
@@ -2261,63 +2316,97 @@ import_disks() {
             found_device=$(find_matching_disk "$disk_id")
         fi
 
-        # Check if device exists and has an available partition
-        local partition=""
-        if [ -n "$found_device" ]; then
+        if [ -z "$found_device" ]; then
+            echo -e "${YELLOW}Warning: Could not find physical disk for ID: ${short_id}${NC}"
+            continue
+        fi
+
+        # The kernel driver does not persist a disk's import offset in its
+        # on-disk superblock, so if this disk was originally imported with an
+        # explicit numeric offset, reuse the offset nmdctl recorded at
+        # create/add time. This ensures the size is (re)computed exactly the
+        # same way it was at creation, avoiding a spurious size mismatch.
+        local saved_offset
+        saved_offset=$(get_saved_disk_offset "$disk_id")
+
+        local import_device=""
+        local offset=0
+
+        if [ "$saved_offset" -gt 0 ]; then
+            # Raw whole-disk import with the recorded offset
+            import_device="$found_device"
+            offset="$saved_offset"
+        else
+            # No recorded offset: fall back to the standard partition-based
+            # import (or a raw whole-disk import if there's no partition at
+            # all, e.g. a raw parity disk).
+            local partition
             partition="$(find_partition "$found_device")"
             local find_rc=$?
             if [ "$find_rc" -eq 2 ]; then
                 echo -e "${YELLOW}Warning: Partition $partition on $found_device is locked by another process, skipping${NC}"
                 partition=""
             fi
+
             if [ -n "$partition" ]; then
-                # Get the partition size
-                local disk_size=$(get_disk_size_kb "$partition")
+                import_device="$partition"
+                offset=0
+            elif [ "$find_rc" -ne 2 ]; then
+                # Determine if this disk has any partition at all (used or not)
+                local has_partition
+                has_partition=$(lsblk -lpno KNAME "$found_device" 2>/dev/null | grep -v -w "^$found_device$" | head -1)
 
-                if [ -n "$disk_size" ]; then
-                    # Get the configured size from nmdstat
-                    local configured_size=$(get_nmdstat_value "diskSize.$slot")
-                    local size_to_use="$disk_size"
-
-                    # If we have a configured size and it differs from actual size
-                    if [ -n "$configured_size" ] && [ "$configured_size" -gt 0 ] && [ "$configured_size" -ne "$disk_size" ]; then
-                        echo -e "${YELLOW}Warning: Size mismatch for disk in slot $slot${NC}"
-                        echo -e "  Partition size: $disk_size KB"
-                        echo -e "  Expected size : $configured_size KB"
-
-                        if [ "$UNATTENDED" -eq 1 ]; then
-                            # If unattended, do not continue import
-                            echo -e "${RED}Error: Size mismatch for disk in slot $slot (unattended mode)${NC}"
-                            continue
-                        fi
-
-                        # Ask for confirmation
-                        read -r -p "Use the configured size instead of detected size? (y/N): " confirm
-                        if [[ "$confirm" =~ ^[Yy]$ ]]; then
-                            size_to_use="$configured_size"
-                            echo -e "Using configured size: ${BLUE}$configured_size KB${NC}"
-                        else
-                            echo -e "Using detected partition size: ${BLUE}$disk_size KB${NC}"
-                        fi
-                    fi
-
-                    echo -e "Found disk for slot $slot: ${BLUE}$(basename "$partition")${NC} (ID: ${short_id})"
-
-                    # Store partition name without /dev/
-                    partition=$(basename "$partition")
-
-                    # Add to import list: slot, partition, offset, size, erased, id
-                    disks_to_import+=("$slot|$partition|0|$size_to_use|0|$disk_id")
-                    num_disks=$((num_disks + 1))
-                else
-                    echo -e "${YELLOW}Warning: Could not determine size for $partition${NC}"
+                if [ -z "$has_partition" ]; then
+                    # No partition at all: raw whole-disk import
+                    import_device="$found_device"
+                    offset=0
                 fi
-            else
-                echo -e "${YELLOW}Warning: No partition found for disk $found_device${NC}"
             fi
-        else
-            echo -e "${YELLOW}Warning: Could not find physical disk for ID: ${short_id}${NC}"
         fi
+
+        if [ -z "$import_device" ]; then
+            echo -e "${YELLOW}Warning: No usable partition found for disk $found_device${NC}"
+            continue
+        fi
+
+        local disk_size=$(get_disk_size_kb "$import_device" "$offset")
+
+        if [ -z "$disk_size" ]; then
+            echo -e "${YELLOW}Warning: Could not determine size for $import_device${NC}"
+            continue
+        fi
+
+        # Get the configured size from nmdstat
+        local configured_size=$(get_nmdstat_value "diskSize.$slot")
+        local size_to_use="$disk_size"
+
+        # If we have a configured size and it differs from actual size
+        if [ -n "$configured_size" ] && [ "$configured_size" -gt 0 ] && [ "$configured_size" -ne "$disk_size" ]; then
+            echo -e "${YELLOW}Warning: Size mismatch for disk in slot $slot${NC}"
+            echo -e "  Disk size     : $disk_size KB"
+            echo -e "  Expected size : $configured_size KB"
+
+            if [ "$UNATTENDED" -eq 1 ]; then
+                # If unattended, do not continue import
+                echo -e "${RED}Error: Size mismatch for disk in slot $slot (unattended mode)${NC}"
+                continue
+            fi
+
+            # Ask for confirmation
+            read -r -p "Use the configured size instead of detected size? (y/N): " confirm
+            if [[ "$confirm" =~ ^[Yy]$ ]]; then
+                size_to_use="$configured_size"
+                echo -e "Using configured size: ${BLUE}$configured_size KB${NC}"
+            else
+                echo -e "Using detected disk size: ${BLUE}$disk_size KB${NC}"
+            fi
+        fi
+
+        echo -e "Found disk for slot $slot: ${BLUE}$(basename "$import_device")${NC} (ID: ${short_id})$([ "$offset" -gt 0 ] && echo -e " Offset: ${BLUE}$offset${NC}")"
+
+        # Add to import list: slot, device, offset, size, erased, id
+        disks_to_import+=("$slot|$(basename "$import_device")|$offset|$size_to_use|0|$disk_id")
+        num_disks=$((num_disks + 1))
     done
 
     # Check if we found any disks to import
@@ -2876,14 +2965,27 @@ create_array_layout() {
         slot_spec="${param%%:*}"
         local rest="${param#*:}"
 
-        # Now parse the device path and optional ID from rest
-        if [[ "$rest" =~ ^([^:]+):(.+)$ ]]; then
-            # device:ID
-            device_path="${BASH_REMATCH[1]}"
-            provided_disk_id="${BASH_REMATCH[2]}"
-        else
-            # just device
-            device_path="$rest"
+        # Now parse the device path, optional ID, and optional offset from rest
+        # Format: SLOT:DEV[:ID[:OFFSET]]
+        local provided_disk_id=""
+        local provided_offset=0
+
+        # Parse colon-separated fields
+        local -a fields
+        IFS=':' read -ra fields <<< "$rest"
+
+        device_path="${fields[0]}"
+        if [ ${#fields[@]} -ge 2 ]; then
+            # If the second field looks like a number (no non-digit chars and starts with digit), it could be offset
+            # Otherwise treat it as disk ID
+            if [[ "${fields[1]}" =~ ^[0-9]+$ ]]; then
+                provided_offset="${fields[1]}"
+            else
+                provided_disk_id="${fields[1]}"
+                if [ ${#fields[@]} -ge 3 ]; then
+                    provided_offset="${fields[2]}"
+                fi
+            fi
         fi
 
         # Validate device path is not empty
@@ -2945,16 +3047,16 @@ create_array_layout() {
             return 1
         fi
 
-        # Get disk size
-        local size_kb=$(get_disk_size_kb "$device_path")
+        # Get disk size (subtract offset from total size to get usable data region)
+        local size_kb=$(get_disk_size_kb "$device_path" "$provided_offset")
         if [ -z "$size_kb" ] || [ "$size_kb" -le 0 ]; then
             echo -e "${RED}Error: Could not determine size for $device_path${NC}"
             return 1
         fi
 
-        echo -e "Slot ${BLUE}$slot${NC}: ${BLUE}$(basename "$device_path")${NC} ($(format_kbytes "$size_kb" 0 0 "gb") GB) ID: $disk_id"
+        echo -e "Slot ${BLUE}$slot${NC}: ${BLUE}$(basename "$device_path")${NC} ($(format_kbytes "$size_kb" 0 0 "gb") GB) ID: $disk_id"$([ "$provided_offset" -gt 0 ] && echo -e " Offset: ${BLUE}$provided_offset${NC}")
 
-        import_entries+=("$slot|$device_path|$size_kb|$disk_id")
+        import_entries+=("$slot|$device_path|$size_kb|$provided_offset|$disk_id")
         assigned_slots+=("$slot")
     done
 
@@ -2973,15 +3075,16 @@ create_array_layout() {
 
     local import_failed=0
     for entry in "${sorted_entries[@]}"; do
-        IFS='|' read -r slot device_path size_kb disk_id <<< "$entry"
+        IFS='|' read -r slot device_path size_kb offset disk_id <<< "$entry"
 
         echo -e "Importing disk to slot $slot: ${BLUE}$(basename "$device_path")${NC}"
 
-        if ! run_nmd_command "import $slot $(basename "$device_path") 0 $size_kb 0 $disk_id"; then
+        if ! run_nmd_command "import $slot $(basename "$device_path") $offset $size_kb 0 $disk_id"; then
             echo -e "${RED}Error: Failed to import disk to slot $slot${NC}"
             import_failed=1
         else
             echo -e "${GREEN}Successfully imported disk to slot $slot${NC}"
+            save_disk_offset "$disk_id" "$offset"
         fi
     done
 
@@ -3349,14 +3452,15 @@ add_disk() {
         esac
     done
 
-    # Parse parameter if provided in SLOT:DEVICE[:ID] format
+    # Parse parameter if provided in SLOT:DEVICE[:ID[:OFFSET]] format
     local param_slot=""
     local param_device=""
     local param_disk_id=""
+    local param_offset=0
     local use_param_mode=0
 
     if [ -n "$disk_param" ] && [[ "$disk_param" =~ : ]]; then
-        # Check if it matches SLOT:DEVICE[:ID] format
+        # Check if it matches SLOT:DEVICE[:...] format
         if [[ "$disk_param" =~ ^([0-9P-Q]|[12][0-9]|29):(.+)$ ]]; then
             use_param_mode=1
 
@@ -3364,14 +3468,21 @@ add_disk() {
             param_slot="${disk_param%%:*}"
             local rest="${disk_param#*:}"
 
-            # Parse device path and optional ID from rest
-            if [[ "$rest" =~ ^([^:]+):(.+)$ ]]; then
-                # device:ID format
-                param_device="${BASH_REMATCH[1]}"
-                param_disk_id="${BASH_REMATCH[2]}"
-            else
-                # just device
-                param_device="$rest"
+            # Parse colon-separated fields: DEVICE[:ID[:OFFSET]]
+            local -a fields
+            IFS=':' read -ra fields <<< "$rest"
+
+            param_device="${fields[0]}"
+            if [ ${#fields[@]} -ge 2 ]; then
+                # If the second field is numeric, treat as offset
+                if [[ "${fields[1]}" =~ ^[0-9]+$ ]]; then
+                    param_offset="${fields[1]}"
+                else
+                    param_disk_id="${fields[1]}"
+                    if [ ${#fields[@]} -ge 3 ]; then
+                        param_offset="${fields[2]}"
+                    fi
+                fi
             fi
 
             # Convert P/Q notation to slot numbers
@@ -3663,6 +3774,7 @@ add_disk() {
     local selected_size_kb=0
     local selected_size_gb=0
     local selected_disk_id=""
+    local selected_offset=0
 
     if [ "$use_param_mode" -eq 1 ]; then
         # Parameter mode: validate and use the provided device
@@ -3690,7 +3802,7 @@ add_disk() {
         # Set selected device info
         selected_partition="$param_device"
         selected_dev="$parent_dev"
-        selected_size_kb=$(get_disk_size_kb "$param_device")
+        selected_size_kb=$(get_disk_size_kb "$param_device" "$param_offset")
 
         if [ -z "$selected_size_kb" ] || [ "$selected_size_kb" -le 0 ]; then
             echo -e "${RED}Error: Could not determine size for $param_device${NC}"
@@ -3698,6 +3810,7 @@ add_disk() {
         fi
 
         selected_size_gb=$(format_kbytes "$selected_size_kb" 0 0 "gb")
+        selected_offset="$param_offset"
 
         # Get or use provided disk ID
         if [ -n "$param_disk_id" ]; then
@@ -3733,6 +3846,7 @@ add_disk() {
         echo -e "Partition: $(basename "$selected_partition")"
         echo -e "Size: $selected_size_gb GB"
         echo -e "ID: $selected_disk_id"
+        [ "$selected_offset" -gt 0 ] && echo -e "Offset: ${BLUE}$selected_offset${NC} sectors"
         echo ""
     else
         # Interactive mode: display menu and let user select
@@ -3877,10 +3991,12 @@ add_disk() {
     echo -e "Adding disk to array..."
 
     # Import disk: slot, partition, offset, size, erased, id
-    if ! run_nmd_command "import $selected_slot $(basename "$selected_partition") 0 $selected_size_kb $preclear_done $selected_disk_id"; then
+    if ! run_nmd_command "import $selected_slot $(basename "$selected_partition") $selected_offset $selected_size_kb $preclear_done $selected_disk_id"; then
         echo -e "${RED}Error: Failed to add disk to slot $selected_slot${NC}"
         return 1
     fi
+
+    save_disk_offset "$selected_disk_id" "$selected_offset"
 
     echo -e "${GREEN}Successfully added disk to slot $selected_slot${NC}"
     echo ""


### PR DESCRIPTION
For my project I needed to replicate a setup similar to Unraid with nonzero rdevOffset. To support this, I had to change nmdctl to accept offsets. These still default to 0 if not set, so it should be a non-breaking change.