### PR TITLE
md_nonraid: fix build on kernel 7.1 (xor_blocks -> xor_gen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ While this is a fork, we try to keep the changes to driver minimal to make syncs
 | ------------- | --------------------- | ------------- | -------------- | ------ |
 | 6.1 - 6.4 | [nonraid-6.1](https://github.com/qvr/nonraid/tree/nonraid-6.1) | unRAID 6.12.15 (6.1.126-Unraid) | Debian 12 | Contains fixes backported from 6.6 and 6.18 branch |
 | 6.5 - 6.8 | [nonraid-6.6](https://github.com/qvr/nonraid/tree/nonraid-6.6) | unRAID 7.0.1 (6.6.78-Unraid) | Ubuntu 24.04 LTS GA kernel | Contains fixes backported from 6.18 branch |
-| 6.11 - 7.0 | [nonraid-6.18](https://github.com/qvr/nonraid/tree/nonraid-6.18) | unRAID 7.3.0 (6.18.29-Unraid) | Ubuntu 24.04 LTS HWE kernel, Debian 13, Arch, Proxmox VE 9 | |
-| 7.1+ | **Not currently supported** | | | |
+| 6.11 - 7.1 | [nonraid-6.18](https://github.com/qvr/nonraid/tree/nonraid-6.18) | unRAID 7.3.0 (6.18.29-Unraid) | Ubuntu 24.04 LTS HWE kernel, Debian 13, Arch, Proxmox VE 9 | |
 
-The supported kernel version ranges might be inaccurate, the driver has been tested to work on **Ubuntu 24.04 LTS** GA kernel (6.8.0) and HWE kernels (6.11 and 6.14), on **Debian 12** (6.1), on **Debian 13** (6.12), on **Arch Linux** lts kernel (6.12) and stable kernels (6.16, 6.17) and on **Proxmox VE 9** (6.14). Note that kernel versions 6.9 and 6.10 are not supported. You can report other distributions and kernel versions that work in the [discussions](https://github.com/qvr/nonraid/discussions).
+The supported kernel version ranges might be inaccurate, the driver has been tested to work on **Ubuntu 24.04 LTS** GA kernel (6.8.0) and HWE kernels (6.11 and 6.14), on **Debian 12** (6.1), on **Debian 13** (6.12), on **Arch Linux** lts kernel (6.12) and stable kernel (as of 7.1) and on **Proxmox VE 9** (6.14). Note that kernel versions 6.9 and 6.10 are not supported. You can report other distributions and kernel versions that work in the [discussions](https://github.com/qvr/nonraid/discussions).
 
 ## Installation
 

--- a/md_nonraid/Makefile
+++ b/md_nonraid/Makefile
@@ -2,6 +2,9 @@ PWD := $(shell pwd)
 KVERSION := $(shell uname -r)
 HEADERS := /lib/modules/$(KVERSION)/build/
 
+# Include kernel compatibility shims
+ccflags-y += -include $(src)/compat-xor.h
+
 K_MAJOR := $(shell echo $(KVERSION) | cut -f1 -d.)
 K_MINOR := $(shell echo $(KVERSION) | cut -f2 -d.)
 K_GT_6_8 := $(shell [ $(K_MAJOR) -gt 6 -o \( $(K_MAJOR) -eq 6 -a $(K_MINOR) -gt 8 \) ] && echo true)

--- a/md_nonraid/compat-xor.h
+++ b/md_nonraid/compat-xor.h
@@ -1,0 +1,38 @@
+/*
+ * Kernel 7.1+ compatibility shim
+ */
+
+#ifndef NONRAID_COMPAT_XOR_H
+#define NONRAID_COMPAT_XOR_H
+
+#include <linux/version.h>
+
+/*
+ * Kernel 7.1 moved the xor code to lib/raid/xor/ and replaced xor_blocks() with
+ * xor_gen(), which takes an arbitrary source count instead of being capped at
+ * MAX_XOR_BLOCKS. Semantics are otherwise identical: the sources are xor'ed
+ * into @dest, which is also an operand. Keep the driver on the old interface so
+ * the call sites stay in sync with upstream.
+ *
+ * Keeping MAX_XOR_BLOCKS at 4 is not merely conservative: xor_impl.h chunks
+ * min(src_cnt, 4) into the same primitives the old do_2..do_5 used, so at a cap
+ * of 4 the driver never exceeds one chunk and the emitted work is identical.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7,1,0)
+
+/* Declares xor_gen(); must precede the inline below. */
+#include <linux/raid/xor.h>
+
+#ifndef MAX_XOR_BLOCKS
+#define MAX_XOR_BLOCKS 4
+#endif
+
+static inline void xor_blocks(unsigned int count, unsigned int bytes,
+			      void *dest, void **srcs)
+{
+	xor_gen(dest, srcs, count, bytes);
+}
+
+#endif /* LINUX_VERSION_CODE >= 7.1.0 */
+
+#endif /* NONRAID_COMPAT_XOR_H */


### PR DESCRIPTION
Kernel 7.1 moved the xor code from `crypto/xor.c` to `lib/raid/xor/` and replaced `xor_blocks()` with `xor_gen(dest, srcs, src_cnt, bytes)`, dropping `MAX_XOR_BLOCKS`. This breaks the nonraid driver compilation on kernel 7.1.

This PR adds a wrapper for the old `xor_blocks`, thus keeping driver interface intact and easily rebaseable with upstream.

Thanks to @Raudbjorn for figuring this out already in https://github.com/Raudbjorn/nonraid/pull/1, the approach and code are directly lifted from his fork.

Fixes #124 